### PR TITLE
Cut down default dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/JonahPlusPlus/bevy_atmosphere"
 repository = "https://github.com/JonahPlusPlus/bevy_atmosphere"
 
 [dependencies]
-bevy = "0.5.0"
+bevy = { version = "0.5", default-features = false, features = ["render"] }
 
 [dev-dependencies]
 bevy_flycam = "0.5"


### PR DESCRIPTION
You need only renderer. Without `default-features = false`, all default dependencies for bevy become required for this plugin.