### PR TITLE
Update to Bevy 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "bevy_atmosphere"
 description = "A procedural sky plugin for bevy"
-version = "0.1.3"
-edition = "2018"
+version = "0.2.0"
+edition = "2021"
 authors = ["JonahPlusPlus <33059163+JonahPlusPlus@users.noreply.github.com>"]
 license = "MIT"
 documentation = "https://docs.rs/bevy_atmosphere"
@@ -10,11 +10,9 @@ homepage = "https://github.com/JonahPlusPlus/bevy_atmosphere"
 repository = "https://github.com/JonahPlusPlus/bevy_atmosphere"
 
 [dependencies]
-bevy = { version = "0.5", default-features = false, features = ["render"] }
-
-[dev-dependencies]
-bevy = { version = "0.5" }
-bevy_flycam = "0.5"
+bevy = { version = "0.6", default-features = false, features = ["bevy_winit", "x11", "bevy_gilrs", "render"] }
+bevy_flycam = "0.6"
+naga = { version = "0.8.0", features = ["glsl-in"] } # Needed for naga::ShaderStage; will be fixed in next bevy release
 
 [[example]]
 name = "cycle"

--- a/README.MD
+++ b/README.MD
@@ -9,11 +9,11 @@
 use bevy::prelude::*;
 use bevy_atmosphere::*;
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(bevy_atmosphere::AtmosphereMat::default()) // Default Earth sky
         .add_plugins(DefaultPlugins)
         .add_plugin(bevy_atmosphere::AtmospherePlugin { dynamic: false }) // Set to false since we aren't changing the sky's appearance
-        .add_startup_system(setup.system())
+        .add_startup_system(setup)
         .run();
 }
 fn setup(mut commands: Commands) {

--- a/examples/cycle.rs
+++ b/examples/cycle.rs
@@ -10,8 +10,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(PlayerPlugin)// Simple movement for this example
         .add_plugin(AtmospherePlugin { dynamic: true }) // Dynamic is set to true so that the material is updated when the SkyMaterial resource is edited. If it was not set to true, we would have to update ourselves.
-        .add_startup_system(setup_environment.system())
-        .add_system(daylight_cycle.system())
+        .add_startup_system(setup_environment)
+        .add_system(daylight_cycle)
         .run();
 }
 

--- a/examples/cycle.rs
+++ b/examples/cycle.rs
@@ -4,7 +4,7 @@ use bevy_flycam::PlayerPlugin;
 
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(Msaa { samples: 4 })
         .insert_resource(AtmosphereMat::default())// Default AtmosphereMat, we can edit it to simulate another planet
         .add_plugins(DefaultPlugins)
@@ -16,27 +16,27 @@ fn main() {
 }
 
 // Marker for updating the position of the light, not needed unless we have multiple lights
+#[derive(Component)]
 struct Sun;
 
 // We can edit the SkyMaterial resource and it will be updated automatically, as long as ZephyrPlugin.dynamic is true
-fn daylight_cycle(mut sky_mat: ResMut<AtmosphereMat>, mut query: Query<&mut Transform, With<Sun>>, time: Res<Time>) {
+fn daylight_cycle(mut sky_mat: ResMut<AtmosphereMat>, mut query: Query<(&mut Transform, &mut DirectionalLight), With<Sun>>, time: Res<Time>) {
     let mut pos = sky_mat.sun_position;
     let t = time.time_since_startup().as_millis() as f32 / 2000.0;
     pos.y = t.sin();
     pos.z = t.cos();
     sky_mat.sun_position = pos;
 
-    // Since Bevy doesn't have directional lights, so we are just moving a point light around the cube.
-    if let Some(mut light_trans) = query.iter_mut().next() {
-        light_trans.translation = pos * 5.0;
+    if let Some((mut light_trans, mut directional)) = query.single_mut().into() {
+        light_trans.rotation = Quat::from_rotation_x(-pos.y.atan2(pos.z));
+        directional.illuminance = t.sin().max(0.0).powf(2.0) * 100000.0;
     }
 }
 
 // Simple environment
 fn setup_environment(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut materials: ResMut<Assets<StandardMaterial>>) {
     // Our Sun
-    commands.spawn_bundle(LightBundle {
-        transform: Transform::from_translation(Vec3::new(2.0, 1.0, 2.5)),
+    commands.spawn_bundle(DirectionalLightBundle {
         ..Default::default()
     })
         .insert(Sun); // Marks the light as Sun

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!         .insert_resource(bevy_atmosphere::AtmosphereMat::default()) // Default Earth sky
 //!         .add_plugins(DefaultPlugins)
 //!         .add_plugin(bevy_atmosphere::AtmospherePlugin { dynamic: false }) // Set to false since we aren't changing the sky's appearance
-//!         .add_startup_system(setup.system())
+//!         .add_startup_system(setup)
 //!         .run();
 //! }
 //!
@@ -20,13 +20,16 @@
 //! ```
 
 use std::ops::Deref;
-use bevy::prelude::*;
+use bevy::{prelude::*, pbr::NotShadowCaster};
 use bevy::render::camera::Camera;
-use bevy::render::pipeline::PipelineDescriptor;
-use bevy::render::render_graph::RenderGraph;
 
 mod material;
 pub use material::AtmosphereMat;
+use material::{SKY_VERTEX_SHADER_HANDLE, SKY_FRAGMENT_SHADER_HANDLE};
+use naga::ShaderStage;
+
+const SKY_VERTEX_SHADER: &str = include_str!("shaders/sky.vert");
+const SKY_FRAGMENT_SHADER: &str = include_str!("shaders/sky.frag");
 
 /// Sets up the atmosphere and the systems that control it
 ///
@@ -58,12 +61,23 @@ pub struct AtmospherePlugin {
 }
 
 impl Plugin for AtmospherePlugin {
-    fn build(&self, app: &mut AppBuilder) {
-        app.add_asset::<AtmosphereMat>();
-        app.add_startup_system(atmosphere_add_sky_sphere.system());
-        app.add_system(atmosphere_sky_follow.system());
+    fn build(&self, app: &mut App) {
+        let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
+        shaders.set_untracked(
+            SKY_VERTEX_SHADER_HANDLE,
+            Shader::from_glsl(SKY_VERTEX_SHADER, ShaderStage::Vertex),
+        );
+        shaders.set_untracked(
+            SKY_FRAGMENT_SHADER_HANDLE,
+            Shader::from_glsl(SKY_FRAGMENT_SHADER, ShaderStage::Fragment),
+        );
+
+        app.add_plugin(MaterialPlugin::<AtmosphereMat>::default());
+        app.add_startup_system(atmosphere_add_sky_sphere);
+        app.add_system_to_stage(CoreStage::Last, // Should run after transform_propagate_system
+                                atmosphere_sky_follow);
         if self.dynamic {
-            app.add_system(atmosphere_dynamic_sky.system());
+            app.add_system(atmosphere_dynamic_sky);
         }
     }
 }
@@ -71,14 +85,8 @@ impl Plugin for AtmospherePlugin {
 fn atmosphere_add_sky_sphere(mut commands: Commands,
                              mut meshes: ResMut<Assets<Mesh>>,
                              mut sky_materials: ResMut<Assets<AtmosphereMat>>,
-                             pipelines: ResMut<Assets<PipelineDescriptor>>,
-                             shaders: ResMut<Assets<Shader>>,
-                             render_graph: ResMut<RenderGraph>,
                              config: Option<Res<AtmosphereMat>>
 ) {
-
-    let render_pipelines = AtmosphereMat::pipeline(pipelines, shaders, render_graph);
-
     let sky_material = match config {
         None => AtmosphereMat::default(),
         Some(c) => c.deref().clone()
@@ -86,15 +94,14 @@ fn atmosphere_add_sky_sphere(mut commands: Commands,
 
     let sky_material = sky_materials.add(sky_material);
 
-    commands.spawn_bundle(MeshBundle {
+    commands.spawn_bundle(MaterialMeshBundle {
         mesh: meshes.add(Mesh::from(shape::Icosphere { radius: -10.0, subdivisions: 2 })),
-        render_pipelines: render_pipelines.clone(),
+        material: sky_material,
         ..Default::default()
-    })
-        .insert(sky_material);
+    }).insert(NotShadowCaster);
 }
 
-fn atmosphere_sky_follow(camera_transform_query: Query<&Transform, (With<Camera>, Without<Handle<AtmosphereMat>>)>, mut sky_transform_query: Query<&mut Transform, With<Handle<AtmosphereMat>>>) {
+fn atmosphere_sky_follow(camera_transform_query: Query<&GlobalTransform, (With<Camera>, Without<Handle<AtmosphereMat>>)>, mut sky_transform_query: Query<&mut GlobalTransform, With<Handle<AtmosphereMat>>>) {
     if let Some(camera_transform) = camera_transform_query.iter().next() {
         if let Some(mut sky_transform) = sky_transform_query.iter_mut().next() {
             sky_transform.translation = camera_transform.translation;

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,17 +1,19 @@
+use bevy::ecs::system::SystemParamItem;
+use bevy::ecs::system::lifetimeless::SRes;
+use bevy::pbr::{SpecializedMaterial, MaterialPipeline};
 use bevy::prelude::*;
 use bevy::reflect::TypeUuid;
-use bevy::render::pipeline::{PipelineDescriptor, RenderPipeline};
-use bevy::render::render_graph::{base, RenderGraph, AssetRenderResourcesNode};
-use bevy::render::shader::{ShaderStage, ShaderStages};
-use bevy::render::renderer::RenderResources;
+use bevy::render::render_asset::{RenderAsset, PrepareAssetError};
+use bevy::render::render_resource::{Buffer, BindGroup, BufferSize, BufferBindingType, BindingType, BindGroupLayoutEntry, BindGroupLayout, BindGroupLayoutDescriptor, RenderPipelineDescriptor, CompareFunction, BufferUsages, BindGroupDescriptor, BufferInitDescriptor, BindGroupEntry, ShaderStages};
+use bevy::render::renderer::RenderDevice;
+use bevy::render::render_resource::std140::{Std140, AsStd140};
 
-const SKY_VERTEX_SHADER: &str = include_str!("shaders/sky.vert");
-const SKY_FRAGMENT_SHADER: &str = include_str!("shaders/sky.frag");
+pub const SKY_VERTEX_SHADER_HANDLE: HandleUntyped = HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 17795653402514319180);
+pub const SKY_FRAGMENT_SHADER_HANDLE: HandleUntyped = HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 13775252721647315361);
 
 /// Controls the appearance of the sky
 ///
-/// Due to constraints on the shader, namely the number of uniforms in a set being capped off at 8, some fields were combined, therefore, functions are provided to set individual fields
-#[derive(Debug, RenderResources, TypeUuid, Clone)]
+#[derive(Debug, TypeUuid, Clone, AsStd140)]
 #[uuid = "a57878c4-569e-4511-be7c-b0e5b2c983e2"]
 pub struct AtmosphereMat {
     /// Default: (0.0, 6372e3, 0.0)
@@ -21,11 +23,15 @@ pub struct AtmosphereMat {
     /// Default: 22.0
     pub sun_intensity: f32,
     /// Represents Planet radius (Default: 6371e3) and Atmosphere radius (Default: 6471e3)
-    pub radius: Vec2,
+    pub planet_radius: f32,
+    pub atmosphere_radius: f32,
     /// Represents Rayleigh coefficient (Default: (5.5e-6, 13.0e-6, 22.4e-6)) and scale height (Default: 8e3)
-    pub rayleigh: Vec4,
+    pub rayleigh_coefficient: Vec3,
+    pub rayleigh_scale_height: f32,
     /// Represents Mie coefficient (Default: 21e-6), scale height (Default: 1.2e3) and preferred scattering direction (Default: 0.758)
-    pub mie: Vec3
+    pub mie_coefficient: f32,
+    pub mie_scale_height: f32,
+    pub mie_direction: f32,
 }
 
 #[allow(dead_code)]
@@ -47,39 +53,39 @@ impl AtmosphereMat {
 
     /// Sets the planet's radius (in meters)
     pub fn set_planet_radius(&mut self, planet_radius: f32) {
-        self.radius.x = planet_radius;
+        self.planet_radius = planet_radius;
     }
 
     /// Sets the atmosphere's radius (in meters)
     pub fn set_atmosphere_radius(&mut self, atmosphere_radius: f32) {
-        self.radius.y = atmosphere_radius;
+        self.atmosphere_radius = atmosphere_radius;
     }
 
     /// Sets the Rayleigh scattering coefficient
     pub fn set_rayleigh_scattering_coefficient(&mut self, coefficient: Vec3) {
-        self.rayleigh.x = coefficient.x.clone();
-        self.rayleigh.y = coefficient.y.clone();
-        self.rayleigh.z = coefficient.z.clone();
+        self.rayleigh_coefficient.x = coefficient.x.clone();
+        self.rayleigh_coefficient.y = coefficient.y.clone();
+        self.rayleigh_coefficient.z = coefficient.z.clone();
     }
 
     /// Sets the scale height (in meters) for Rayleigh scattering
     pub fn set_rayleigh_scale_height(&mut self, scale: f32) {
-        self.rayleigh.w = scale;
+        self.rayleigh_scale_height = scale;
     }
 
     /// Sets the Mie scattering coefficient
     pub fn set_mie_scattering_coefficient(&mut self, coefficient: f32) {
-        self.mie.x = coefficient;
+        self.mie_coefficient = coefficient;
     }
 
     /// Sets the scale height (in meters) for Mie scattering
     pub fn set_mie_scale_height(&mut self, scale: f32) {
-        self.mie.y = scale;
+        self.mie_scale_height = scale;
     }
 
     /// Sets the preferred direction for Mie scattering
     pub fn set_mie_scattering_direction(&mut self, direction: f32) {
-        self.mie.z = direction;
+        self.mie_direction = direction;
     }
 }
 
@@ -89,37 +95,95 @@ impl Default for AtmosphereMat {
             ray_origin: Vec3::new(0.0, 6372e3, 0.0),
             sun_position: Vec3::new(0.0, 1.0, 1.0),
             sun_intensity: 22.0,
-            radius: Vec2::new(6371e3, 6471e3),
-            rayleigh: Vec4::new(5.5e-6, 13.0e-6, 22.4e-6, 8e3),
-            mie: Vec3::new(21e-6, 1.2e3, 0.758),
+            planet_radius: 6371e3,
+            atmosphere_radius: 6471e3,
+            rayleigh_coefficient: Vec3::new(5.5e-6, 13.0e-6, 22.4e-6),
+            rayleigh_scale_height: 8e3,
+            mie_coefficient: 21e-6,
+            mie_scale_height: 1.2e3,
+            mie_direction: 0.758,
         }
     }
 }
 
-impl AtmosphereMat {
-    pub fn pipeline(
-        mut pipelines: ResMut<Assets<PipelineDescriptor>>,
-        mut shaders: ResMut<Assets<Shader>>,
-        mut render_graph: ResMut<RenderGraph>
-    ) -> RenderPipelines {
-        let mut descriptor = PipelineDescriptor::default_config(ShaderStages {
-            vertex: shaders.add(Shader::from_glsl(ShaderStage::Vertex, SKY_VERTEX_SHADER)),
-            fragment: Some(shaders.add(Shader::from_glsl(ShaderStage::Fragment, SKY_FRAGMENT_SHADER)))
+#[derive(Clone)]
+pub struct GpuAtmosphereMat {
+    _buffer: Buffer,
+    bind_group: BindGroup,
+}
+
+impl RenderAsset for AtmosphereMat {
+    type ExtractedAsset = AtmosphereMat;
+    type PreparedAsset = GpuAtmosphereMat;
+    type Param = (SRes<RenderDevice>, SRes<MaterialPipeline<Self>>);
+    fn extract_asset(&self) -> Self {
+        self.clone()
+    }
+
+    fn prepare_asset(
+        extracted_asset: Self,
+        (render_device, material_pipeline): &mut SystemParamItem<Self::Param>,
+    ) -> Result<Self::PreparedAsset, PrepareAssetError<Self>> {
+        let buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+            contents: extracted_asset.as_std140().as_bytes(),
+            label: None,
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
         });
-        descriptor.depth_stencil = descriptor.depth_stencil.map(|mut depth_stencil_state| {
-            depth_stencil_state.depth_compare = bevy::render::pipeline::CompareFunction::LessEqual;
+        let bind_group = render_device.create_bind_group(&BindGroupDescriptor {
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: buffer.as_entire_binding(),
+            }],
+            label: None,
+            layout: &material_pipeline.material_layout,
+        });
+
+        Ok(Self::PreparedAsset {
+            _buffer: buffer,
+            bind_group,
+        })
+    }
+}
+
+impl SpecializedMaterial for AtmosphereMat {
+    type Key = ();
+
+    fn key(_: &<AtmosphereMat as RenderAsset>::PreparedAsset) -> Self::Key {}
+
+    fn specialize(_: Self::Key, descriptor: &mut RenderPipelineDescriptor) {
+        descriptor.vertex.entry_point = "main".into();
+        descriptor.fragment.as_mut().unwrap().entry_point = "main".into();
+        if let Some(depth_stencil_state) = &mut descriptor.depth_stencil {
+            depth_stencil_state.depth_compare = CompareFunction::GreaterEqual;
             depth_stencil_state.depth_write_enabled = false;
-            depth_stencil_state
-        });
+        }
+    }
 
-        let sky_pipeline_handle = pipelines.add(descriptor);
-        render_graph.add_system_node(
-            "AtmosphereMat",
-            AssetRenderResourcesNode::<AtmosphereMat>::new(true),
-        );
-        render_graph.add_node_edge("AtmosphereMat", base::node::MAIN_PASS).unwrap();
+    fn vertex_shader(_: &AssetServer) -> Option<Handle<Shader>> {
+        Some(SKY_VERTEX_SHADER_HANDLE.typed())
+    }
 
-        let render_pipelines = RenderPipelines::from_pipelines(vec![RenderPipeline::new(sky_pipeline_handle)]);
-        render_pipelines
+    fn fragment_shader(_: &AssetServer) -> Option<Handle<Shader>> {
+        Some(SKY_FRAGMENT_SHADER_HANDLE.typed())
+    }
+
+    fn bind_group(render_asset: &<Self as RenderAsset>::PreparedAsset) -> &BindGroup {
+        &render_asset.bind_group
+    }
+
+    fn bind_group_layout(render_device: &RenderDevice) -> BindGroupLayout {
+        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            entries: &[BindGroupLayoutEntry {
+                binding: 0,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: BufferSize::new(AtmosphereMat::std140_size_static() as u64),
+                },
+                count: None,
+            }],
+            label: None,
+        })
     }
 }

--- a/src/shaders/sky.frag
+++ b/src/shaders/sky.frag
@@ -5,28 +5,17 @@ precision highp float;
 layout(location = 0) in vec3 v_Pos;
 layout(location = 0) out vec4 o_Target;
 
-layout(std140, set = 2, binding = 0) uniform AtmosphereMat_ray_origin {
+layout(std140, set = 1, binding = 0) uniform AtmosphereMat_ray_origin {
     vec3 ray_origin;
-};
-
-layout(std140, set = 2, binding = 1) uniform AtmosphereMat_sun_position {
     vec3 sun_position;
-};
-
-layout(std140, set = 2, binding = 2) uniform AtmosphereMat_sun_intensity {
     float sun_intensity;
-};
-
-layout(std140, set = 2, binding = 3) uniform AtmosphereMat_radius {
-    vec2 radius;
-};
-
-layout(std140, set = 2, binding = 4) uniform AtmosphereMat_rayleigh {
-    vec4 rayleigh;
-};
-
-layout(std140, set = 2, binding = 5) uniform AtmosphereMat_mie {
-    vec3 mie;
+    float planet_radius;
+    float atmosphere_radius;
+    vec3 rayleigh_coefficient;
+    float rayleigh_scale_height;
+    float mie_coefficient;
+    float mie_scale_height;
+    float mie_direction;
 };
 
 #define PI 3.141592
@@ -139,17 +128,17 @@ vec3 atmosphere(vec3 r, vec3 r0, vec3 pSun, float iSun, float rPlanet, float rAt
 
 void main() {
     vec3 sky = atmosphere(
-        normalize(v_Pos),   // normalized ray direction
-        ray_origin,         // ray origin
-        sun_position,       // position of the sun
-        sun_intensity,      // intensity of the sun
-        radius.x,           // radius of the planet in meters
-        radius.y,           // radius of the atmosphere in meters
-        rayleigh.xyz,       // Rayleigh scattering coefficient
-        mie.x,              // Mie scattering coefficient
-        rayleigh.w,         // Rayleigh scale height
-        mie.y,              // Mie scale height
-        mie.z               // Mie preferred scattering direction
+        normalize(v_Pos),      // normalized ray direction
+        ray_origin,            // ray origin
+        sun_position,          // position of the sun
+        sun_intensity,         // intensity of the sun
+        planet_radius,         // radius of the planet in meters
+        atmosphere_radius,     // radius of the atmosphere in meters
+        rayleigh_coefficient,  // Rayleigh scattering coefficient
+        mie_coefficient,       // Mie scattering coefficient
+        rayleigh_scale_height, // Rayleigh scale height
+        mie_scale_height,      // Mie scale height
+        mie_direction          // Mie preferred scattering direction
     );
 
     sky = 1.0 - exp(-1.0 * sky);

--- a/src/shaders/sky.vert
+++ b/src/shaders/sky.vert
@@ -6,14 +6,22 @@ layout(location = 2) in vec2 Vertex_Uv;
 
 layout(location = 0) out vec3 v_Pos;
 
-
 layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
-};
-layout(set = 1, binding = 0) uniform Transform {
-    mat4 Model;
+    mat4 InverseView;
+    mat4 Projection;
+    vec3 WorldPosition;
+    float near;
+    float far;
+    float width;
+    float height;
 };
 
+layout(set = 2, binding = 0) uniform Mesh {
+    mat4 Model;
+    mat4 InverseTransposeModel;
+    uint flags;
+};
 
 void main() {
     v_Pos = Vertex_Position;


### PR DESCRIPTION
Bevy 0.6 features a new renderer, so the changes are quite extensive. Mostly just followed the official examples for custom shaders.

In the shader, I put all the uniforms into a single bind group and separated combined fields.

I modified the system that moves the sky sphere to use `GlobalTransform`s. This is needed for cameras whose position is affected by their parents.

Also changed the way the shaders are loaded. Taken from https://github.com/ForesightMiningSoftwareCorporation/bevy_transform_gizmo/blob/main/src/gizmo_material.rs#L18

In the example, I changed the point light to a directional light.

