### PR TITLE
Reduce Bevy dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/JonahPlusPlus/bevy_atmosphere"
 repository = "https://github.com/JonahPlusPlus/bevy_atmosphere"
 
 [dependencies]
-bevy = { version = "0.6", default-features = false, features = ["render"] }
+bevy = { version = "0.6", default-features = false, features = ["bevy_render", "bevy_pbr"] }
 naga = { version = "0.8.0", features = ["glsl-in"] } # Needed for naga::ShaderStage; will be fixed in next bevy release
 
 [dev-dependencies]


### PR DESCRIPTION
Previously used `render` feature is a [group](
https://github.com/bevyengine/bevy/blob/a291b5aaedb4affcb31df2e2e63cb0c665ffb24a/Cargo.toml#L35-L43) that contains unneeded stuff, like `bevy_ui` or `bevy_text`. Specified features in this PR is the required minimum. You can read more about in in this issue: https://github.com/bevyengine/bevy/issues/4202