### PR TITLE
Increase default sky radius

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!         .add_plugins(DefaultPlugins)
 //!         .add_plugin(bevy_atmosphere::AtmospherePlugin {
 //!             dynamic: false,  // Set to false since we aren't changing the sky's appearance
-//!             sky_radius: 500.0
+//!             sky_radius: 100.0
 //!         })
 //!         .add_startup_system(setup)
 //!         .run();
@@ -72,7 +72,7 @@ impl Default for AtmospherePlugin {
     fn default() -> Self {
         Self {
             dynamic: false,
-            sky_radius: 500.0,
+            sky_radius: 100.0,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!         .add_plugins(DefaultPlugins)
 //!         .add_plugin(bevy_atmosphere::AtmospherePlugin {
 //!             dynamic: false,  // Set to false since we aren't changing the sky's appearance
-//!             sky_radius: 10.0
+//!             sky_radius: 500.0
 //!         })
 //!         .add_startup_system(setup)
 //!         .run();
@@ -72,7 +72,7 @@ impl Default for AtmospherePlugin {
     fn default() -> Self {
         Self {
             dynamic: false,
-            sky_radius: 10.0,
+            sky_radius: 500.0,
         }
     }
 }


### PR DESCRIPTION
10.0 ends up giving some weird side effects sometimes.

e.g. while using bevy_rapier the debug lines cut out very close to the camera.