### PR TITLE
Remove unnecessary atan2.

### DIFF
--- a/examples/cycle.rs
+++ b/examples/cycle.rs
@@ -40,7 +40,7 @@ fn daylight_cycle(
         atmosphere.sun_position = Vec3::new(0., t.sin(), t.cos());
 
         if let Some((mut light_trans, mut directional)) = query.single_mut().into() {
-            light_trans.rotation = Quat::from_rotation_x(-t.sin().atan2(t.cos()));
+            light_trans.rotation = Quat::from_rotation_x(-t);
             directional.illuminance = t.sin().max(0.0).powf(2.0) * 100000.0;
         }
     }


### PR DESCRIPTION
Simplifies the following atan2 statement in the cycle example.
```rs
light_trans.rotation = Quat::from_rotation_x(-t.sin().atan2(t.cos()));
```
to
```rs
light_trans.rotation = Quat::from_rotation_x(-t);
```
Proof: $-\arctan \left(\dfrac{\sin t}{\cos t}\right) = -\arctan (\tan t) = -t$

Testing it worked as expected.
I know this is kinda dumb, but I just couldn't help it :)