### PR TITLE
[need help] bevy 0.11 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ repository = "https://github.com/JonahPlusPlus/bevy_atmosphere"
 exclude = ["/assets/", "/examples/", "/.github/"]
 
 [dependencies]
-bevy = {version = "0.10", default-features = false, features = ["bevy_asset", "bevy_render", "bevy_pbr"]}
+bevy = {version = "0.11", default-features = false, features = ["bevy_asset", "bevy_render", "bevy_pbr"]}
 bevy_atmosphere_macros = {path = "macros", version = "0.2"}
 cfg-if = "1.0"
 
 [dev-dependencies]
 bevy_spectator = "0.2"
-bevy = { version = "0.10", features = ["bevy_core_pipeline", "x11"] } # load all in case docs.rs complains
+bevy = { version = "0.11", features = ["bevy_core_pipeline", "x11"] } # load all in case docs.rs complains
 
 [features]
 default = ["basic", "all_models"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default = ["basic", "all_models"]
 basic = ["detection", "dithering", "procedural"] # enables basic features
 detection = [] # enables camera detection (disable to add skyboxes manually)
 dithering = [] # enables dithering (disable for banding)
-procedural = [] # enables the automatic addition of `AtmospherePipelinePlugin` from `AtmospherePlugin` (disable to edit the sky texture manually)
+procedural = [] # enables the automatic addition of `AtmospherePipeline` setup from `AtmospherePlugin` (disable to edit the sky texture manually)
 # models
 all_models = [ "gradient", "nishita"] # enables all models
 gradient = [] # enables the gradient model

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ use bevy_atmosphere::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AtmospherePlugin)
-        .add_startup_system(setup)
+        .add_plugins(AtmospherePlugin)
+        .add_systems(Update, setup)
         .run();
 }
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(AtmospherePlugin)
-        .add_systems(Update, setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -4,8 +4,8 @@ use bevy_atmosphere::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AtmospherePlugin)
-        .add_startup_system(setup)
+        .add_plugins(AtmospherePlugin)
+        .add_systems(Update, setup)
         .run();
 }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,7 +5,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(AtmospherePlugin)
-        .add_systems(Update, setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/cycle.rs
+++ b/examples/cycle.rs
@@ -11,10 +11,10 @@ fn main() {
             TimerMode::Repeating,
         )))
         .add_plugins(DefaultPlugins)
-        .add_plugin(SpectatorPlugin) // Simple movement for this example
-        .add_plugin(AtmospherePlugin) // Default AtmospherePlugin
-        .add_startup_system(setup_environment)
-        .add_system(daylight_cycle)
+        .add_plugins(SpectatorPlugin) // Simple movement for this example
+        .add_plugins(AtmospherePlugin) // Default AtmospherePlugin
+        .add_systems(Startup, setup_environment)
+        .add_systems(Update, daylight_cycle)
         .run();
 }
 

--- a/examples/detection.rs
+++ b/examples/detection.rs
@@ -5,9 +5,9 @@ fn main() {
     println!("Demonstrates adding/removing an `AtmosphereCamera`\n\t- Left Mouse Button: Add `AtmosphereCamera`\n\t- Right Mouse Button: Remove `AtmosphereCamera`");
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AtmospherePlugin)
-        .add_startup_system(setup)
-        .add_system(update)
+        .add_plugins(AtmospherePlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, update)
         .run();
 }
 

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -7,10 +7,10 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .insert_resource(AtmosphereModel::new(Gradient::default()))
-        .add_plugin(AtmospherePlugin)
-        .add_plugin(SpectatorPlugin)
-        .add_startup_system(setup)
-        .add_system(change_gradient)
+        .add_plugins(AtmospherePlugin)
+        .add_plugins(SpectatorPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, change_gradient)
         .run();
 }
 

--- a/examples/models.rs
+++ b/examples/models.rs
@@ -6,10 +6,10 @@ fn main() {
     println!("Demonstrates changing the atmosphere model\n\t- G: Gradient\n\t- N: Nishita");
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AtmospherePlugin)
-        .add_plugin(SpectatorPlugin)
-        .add_startup_system(setup)
-        .add_system(change_model)
+        .add_plugins(AtmospherePlugin)
+        .add_plugins(SpectatorPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, change_model)
         .run();
 }
 

--- a/examples/nishita.rs
+++ b/examples/nishita.rs
@@ -6,10 +6,10 @@ fn main() {
     println!("Demonstrates using the `Nishita` model\n\t- 1-9 number keys: Change preset\n\t- 0 number key: Remove `Nishita` model");
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AtmospherePlugin)
-        .add_plugin(SpectatorPlugin)
-        .add_startup_system(setup)
-        .add_system(change_nishita)
+        .add_plugins(AtmospherePlugin)
+        .add_plugins(SpectatorPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, change_nishita)
         .run();
 }
 

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -10,10 +10,10 @@ fn main() {
             ..default()
         })
         .add_plugins(DefaultPlugins)
-        .add_plugin(AtmospherePlugin)
-        .add_plugin(SpectatorPlugin)
-        .add_startup_system(setup)
-        .add_system(change_resolution)
+        .add_plugins(AtmospherePlugin)
+        .add_plugins(SpectatorPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, change_resolution)
         .run();
 }
 

--- a/examples/splitscreen.rs
+++ b/examples/splitscreen.rs
@@ -24,11 +24,11 @@ fn main() {
             ..default()
         })
         .add_plugins(DefaultPlugins)
-        .add_plugin(AtmospherePlugin)
-        .add_plugin(SpectatorPlugin)
-        .add_startup_system(setup)
-        .add_system(set_camera_viewports)
-        .add_system(switch_camera)
+        .add_plugins(AtmospherePlugin)
+        .add_plugins(SpectatorPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, set_camera_viewports)
+        .add_systems(Update, switch_camera)
         .run();
 }
 

--- a/macros/src/model.rs
+++ b/macros/src/model.rs
@@ -47,7 +47,7 @@ pub fn derive_atmospheric(ast: syn::DeriveInput) -> Result<TokenStream> {
     let atmosphere_path = super::bevy_atmosphere_path();
     let render_path = manifest.get_path("bevy_render");
     let asset_path = manifest.get_path("bevy_asset");
-    let app_path = manifest.get_path("bevy_app");
+    let ecs_path = manifest.get_path("bevy_ecs");
 
     let id = {
         use std::collections::hash_map::DefaultHasher;
@@ -483,7 +483,7 @@ pub fn derive_atmospheric(ast: syn::DeriveInput) -> Result<TokenStream> {
                     pipeline,
                 };
 
-                let type_registry = app.world.resource_mut::<#app_path::AppTypeRegistry>();
+                let type_registry = app.world.resource_mut::<#ecs_path::reflect::AppTypeRegistry>();
                 {
                     let mut type_registry = type_registry.write();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@
 //! fn main() {
 //!     App::new()
 //!         .add_plugins(DefaultPlugins)
-//!         .add_plugin(AtmospherePlugin)
-//!         .add_startup_system(setup)
+//!         .add_plugins(AtmospherePlugin)
+//!         .add_systems(Startup, setup)
 //!         .run();
 //! }
 //!

--- a/src/model.rs
+++ b/src/model.rs
@@ -99,7 +99,7 @@ pub trait RegisterAtmosphereModel: GetTypeRegistration {
 /// fn main() {
 ///     App::new()
 ///         .add_plugins(DefaultPlugins)
-///         .add_plugin(AtmospherePlugin)
+///         .add_plugins(AtmospherePlugin)
 ///         .add_atmosphere_model::<MyModel>()
 ///         .insert_resource(AtmosphereModel::new(MyModel::default()))
 ///         .run();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -32,7 +32,7 @@ impl Plugin for AtmospherePlugin {
         app.add_plugins(MaterialPlugin::<SkyBoxMaterial>::default());
 
         #[cfg(feature = "procedural")]
-        app.add_plugins(AtmospherePipelinePlugin);
+        build_atmosphere_pipeline(app);
 
         {
             let image_handle = {
@@ -61,6 +61,11 @@ impl Plugin for AtmospherePlugin {
         }
 
         app.add_systems(Update, atmosphere_cancel_rotation);
+    }
+
+    fn finish(&self, app: &mut App) {
+        #[cfg(feature = "procedural")]
+        finish_atmosphere_pipeline(app);
 
         #[cfg(feature = "gradient")]
         app.add_atmosphere_model::<crate::collection::gradient::Gradient>();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -29,10 +29,10 @@ impl Plugin for AtmospherePlugin {
             Shader::from_wgsl
         );
 
-        app.add_plugin(MaterialPlugin::<SkyBoxMaterial>::default());
+        app.add_plugins(MaterialPlugin::<SkyBoxMaterial>::default());
 
         #[cfg(feature = "procedural")]
-        app.add_plugin(AtmospherePipelinePlugin);
+        app.add_plugins(AtmospherePipelinePlugin);
 
         {
             let image_handle = {
@@ -57,12 +57,10 @@ impl Plugin for AtmospherePlugin {
 
         #[cfg(feature = "detection")]
         {
-            app.add_systems(
-                (atmosphere_insert, atmosphere_remove).in_base_set(CoreSet::PostUpdate),
-            );
+            app.add_systems(PostUpdate, (atmosphere_insert, atmosphere_remove));
         }
 
-        app.add_system(atmosphere_cancel_rotation);
+        app.add_systems(Update, atmosphere_cancel_rotation);
 
         #[cfg(feature = "gradient")]
         app.add_atmosphere_model::<crate::collection::gradient::Gradient>();

--- a/src/shaders/skybox.wgsl
+++ b/src/shaders/skybox.wgsl
@@ -10,6 +10,8 @@ fn dither(frag_coord: vec2<f32>) -> vec3<f32> {
 }
 #endif
 
+#import bevy_pbr::mesh_vertex_output MeshVertexOutput
+
 @group(1) @binding(0)
 var sky_texture: texture_cube<f32>;
 @group(1) @binding(1)
@@ -17,12 +19,11 @@ var sky_sampler: sampler;
 
 @fragment
 fn fragment(
-    #import bevy_pbr::mesh_vertex_output
-    @builtin(position) position: vec4<f32>
+    in: MeshVertexOutput,
 ) -> @location(0) vec4<f32> {
-    let color = textureSample(sky_texture, sky_sampler, world_normal).xyz;
+    let color = textureSample(sky_texture, sky_sampler, in.world_normal).xyz;
 #ifdef DITHER
-    return vec4<f32>(color + dither(position.xy), 1f);
+    return vec4<f32>(color + dither(in.position.xy), 1f);
 #else
     return vec4<f32>(color, 1f);
 #endif

--- a/src/skybox.rs
+++ b/src/skybox.rs
@@ -3,7 +3,7 @@
 use bevy::{
     pbr::{MaterialPipeline, MaterialPipelineKey},
     prelude::*,
-    reflect::TypeUuid,
+    reflect::{TypePath, TypeUuid},
     render::{
         mesh::{Indices, Mesh, MeshVertexBufferLayout, PrimitiveTopology},
         render_resource::{AsBindGroup, RenderPipelineDescriptor, ShaderDefVal, ShaderRef},
@@ -19,7 +19,7 @@ pub const ATMOSPHERE_SKYBOX_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 4511926918914205353);
 
 /// The `Material` that renders skyboxes.
-#[derive(AsBindGroup, TypeUuid, Debug, Clone)]
+#[derive(AsBindGroup, TypePath, TypeUuid, Debug, Clone)]
 #[uuid = "b460ff90-0ee4-42df-875f-0a62ecd1301c"]
 #[bind_group_data(SkyBoxMaterialKey)]
 pub struct SkyBoxMaterial {

--- a/src/system_param.rs
+++ b/src/system_param.rs
@@ -4,8 +4,9 @@ use std::ops::{Deref, DerefMut};
 
 use bevy::{
     ecs::{
-        component::ComponentId,
+        component::{ComponentId, Tick},
         system::{ReadOnlySystemParam, SystemMeta, SystemParam},
+        world::unsafe_world_cell::UnsafeWorldCell,
     },
     prelude::*,
 };
@@ -40,8 +41,8 @@ unsafe impl<T: Atmospheric> SystemParam for Atmosphere<'_, T> {
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
         system_meta: &SystemMeta,
-        world: &'w World,
-        change_tick: u32,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
     ) -> Self::Item<'w, 's> {
         let atmosphere_model = <Res<AtmosphereModel> as SystemParam>::get_param(
             state,
@@ -88,8 +89,8 @@ unsafe impl<T: Atmospheric> SystemParam for AtmosphereMut<'_, T> {
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
         system_meta: &SystemMeta,
-        world: &'w World,
-        change_tick: u32,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
     ) -> Self::Item<'w, 's> {
         let atmosphere_model = <ResMut<AtmosphereModel> as SystemParam>::get_param(
             state,


### PR DESCRIPTION
In this PR there are obvious changes. I made them, so you don't have to.

The problem: `macros` [subcrate](https://github.com/JonahPlusPlus/bevy_atmosphere/tree/master/macros) depends on `syn 1`, but bevy updated to `syn 2`.

Anyone here knows proc macros? Can you update `macro` folder, pretty please?