### PR TITLE
Update Bevy to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/JonahPlusPlus/bevy_atmosphere"
 exclude = ["/assets/", "/examples/", "/.github/"]
 
 [dependencies]
-bevy = { version = "0.11", default-features = false, features = [
+bevy = { version = "0.12", default-features = false, features = [
   "bevy_asset",
   "bevy_render",
   "bevy_pbr",
@@ -21,7 +21,7 @@ cfg-if = "1.0"
 
 [dev-dependencies]
 bevy_spectator = "0.3"
-bevy = { version = "0.11", features = ["bevy_core_pipeline", "x11"] }
+bevy = { version = "0.12", features = ["bevy_core_pipeline", "x11"] }
 
 [features]
 default = ["basic", "all_models"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bevy_atmosphere_macros = { path = "macros", version = "0.2.1" }
 cfg-if = "1.0"
 
 [dev-dependencies]
-bevy_spectator = "0.3"
+bevy_spectator = "0.4"
 bevy = { version = "0.12", features = ["bevy_core_pipeline", "x11"] }
 
 [features]

--- a/examples/splitscreen.rs
+++ b/examples/splitscreen.rs
@@ -116,7 +116,7 @@ fn set_camera_viewports(
     // We need to dynamically resize the camera's viewports whenever the window size changes
     // so then each camera always takes up half the screen.
     // A resize_event is sent when the window is first created, allowing us to reuse this system for initial setup.
-    for resize_event in resize_events.iter() {
+    for resize_event in resize_events.read() {
         let window = windows.get(resize_event.window).unwrap();
         let mut left_camera = left_camera.single_mut();
         left_camera.viewport = Some(Viewport {

--- a/macros/src/model.rs
+++ b/macros/src/model.rs
@@ -143,7 +143,7 @@ pub fn derive_atmospheric(ast: syn::DeriveInput) -> Result<TokenStream> {
         ShaderPathType::Internal(s) => quote! {
             {
                 use bevy::reflect::TypeUuid;
-                let handle = #asset_path::HandleUntyped::weak_from_u64(#render_path::render_resource::Shader::TYPE_UUID, #id);
+                let handle: #asset_path::Handle<Shader> = #asset_path::Handle::weak_from_u128(#id as u128);
 
                 let internal_handle = handle.clone();
                 #asset_path::load_internal_asset!(
@@ -153,7 +153,7 @@ pub fn derive_atmospheric(ast: syn::DeriveInput) -> Result<TokenStream> {
                     Shader::from_wgsl
                 );
 
-                handle.typed()
+                handle
             }
         },
     };
@@ -423,14 +423,9 @@ pub fn derive_atmospheric(ast: syn::DeriveInput) -> Result<TokenStream> {
             ) -> #render_path::render_resource::BindGroup {
                 let bindings = vec![#(#binding_impls,)*];
 
-                let bind_group = {
-                    let descriptor = #render_path::render_resource::BindGroupDescriptor {
-                        entries: &[#(#bind_group_entries,)*],
-                        label: None,
-                        layout: &layout,
-                    };
-                    render_device.create_bind_group(&descriptor)
-                };
+                let bind_group =
+                    render_device.create_bind_group(
+                        None, &layout, &[#(#bind_group_entries,)*]);
                 bind_group
             }
 

--- a/src/collection/gradient.rs
+++ b/src/collection/gradient.rs
@@ -6,7 +6,7 @@ use bevy::{prelude::*, render::render_resource::ShaderType};
 /// A simple gradient for creating a stylized environment.
 #[derive(Atmospheric, ShaderType, Reflect, Debug, Clone)]
 #[uniform(0, Gradient)]
-#[internal("shaders/gradient.wgsl")]
+#[internal("../shaders/gradient.wgsl")]
 pub struct Gradient {
     /// Sky Color (Default: `Color::rgb(0.29, 0.41, 0.50)`).
     /// <div style="background-color:rgb(29%, 41%, 50%); width: 10px; padding: 10px; border: 1px solid;"></div>

--- a/src/collection/nishita.rs
+++ b/src/collection/nishita.rs
@@ -6,7 +6,7 @@ use bevy::{prelude::*, render::render_resource::ShaderType};
 /// An atmospheric model that uses Rayleigh and Mie scattering to simulate a realistic sky.
 #[derive(Atmospheric, ShaderType, Reflect, Debug, Clone)]
 #[uniform(0, Nishita)]
-#[internal("shaders/nishita.wgsl")]
+#[internal("../shaders/nishita.wgsl")]
 pub struct Nishita {
     /// Ray Origin (Default: `(0.0, 6372e3, 0.0)`).
     ///

--- a/src/model.rs
+++ b/src/model.rs
@@ -116,9 +116,9 @@ impl AddAtmosphereModel for App {
     }
 }
 
-/// A `Resource` that stores an [`Atmospheric`](crate::model::Atmospheric) model.
+/// A `Resource` that stores an [`Atmospheric`] model.
 ///
-/// Acts as a wrapper for accessing an [`Atmospheric`](crate::model::Atmospheric) model as a resource.
+/// Acts as a wrapper for accessing an [`Atmospheric`] model as a resource.
 #[derive(Resource, ExtractResource, Clone)]
 pub struct AtmosphereModel {
     model: Box<dyn Atmospheric>,
@@ -131,31 +131,31 @@ impl From<&AtmosphereModel> for AtmosphereModel {
 }
 
 impl AtmosphereModel {
-    /// Creates a new `AtmosphereModel` from a [`Atmospheric`](crate::model::Atmospheric) model.
+    /// Creates a new `AtmosphereModel` from a [`Atmospheric`] model.
     pub fn new(model: impl Atmospheric + 'static) -> Self {
         Self {
             model: Box::new(model),
         }
     }
 
-    /// Get a reference of the underlying [`Atmospheric`](crate::model::Atmospheric) trait object.
+    /// Get a reference of the underlying [`Atmospheric`] trait object.
     #[inline]
     pub fn model(&self) -> &dyn Atmospheric {
         &*self.model
     }
 
-    /// Get a mutable reference of the underlying [`Atmospheric`](crate::model::Atmospheric) trait object.
+    /// Get a mutable reference of the underlying [`Atmospheric`] trait object.
     #[inline]
     pub fn model_mut(&mut self) -> &mut dyn Atmospheric {
         &mut *self.model
     }
 
-    /// Convert the underlying model to a reference of the specified [`Atmospheric`](crate::model::Atmospheric) model.
+    /// Convert the underlying model to a reference of the specified [`Atmospheric`] model.
     pub fn to_ref<T: Atmospheric>(&self) -> Option<&T> {
         Atmospheric::as_reflect(&*self.model).downcast_ref()
     }
 
-    /// Convert the underlying model to a mutable reference of the specified [`Atmospheric`](crate::model::Atmospheric) model.
+    /// Convert the underlying model to a mutable reference of the specified [`Atmospheric`] model.
     pub fn to_mut<T: Atmospheric>(&mut self) -> Option<&mut T> {
         Atmospheric::as_reflect_mut(&mut *self.model).downcast_mut()
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -5,6 +5,7 @@
 use std::ops::Deref;
 
 use bevy::{
+    ecs::event::event_update_system,
     prelude::*,
     render::{
         extract_resource::{ExtractResource, ExtractResourcePlugin},
@@ -142,7 +143,7 @@ impl Plugin for AtmospherePipelinePlugin {
             .add_systems(
                 Render,
                 (
-                    //Events::<AtmosphereUpdateEvent>::update_system.in_set(RenderSet::Prepare),
+                    event_update_system::<AtmosphereUpdateEvent>.in_set(RenderSet::Prepare),
                     prepare_atmosphere_assets.in_set(RenderSet::PrepareAssets),
                     queue_atmosphere_bind_group.in_set(RenderSet::Queue),
                 ),
@@ -397,7 +398,7 @@ fn queue_atmosphere_bind_group(
     let image_bind_group = render_device.create_bind_group(
         "bevy_atmosphere_image_bind_group",
         &image_bind_group_layout.0,
-        &BindGroupEntries::sequential((BindingResource::TextureView(view),)),
+        &BindGroupEntries::single(BindingResource::TextureView(view)),
     );
 
     commands.insert_resource(AtmosphereBindGroups(

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,7 +1,7 @@
 //! Provides a `Plugin` for making skyboxes with procedural sky textures.
 
 use bevy::{
-    asset::load_internal_asset,
+    asset::embedded_asset,
     pbr::{NotShadowCaster, NotShadowReceiver},
     prelude::*,
     render::{
@@ -14,7 +14,7 @@ use bevy::{
 use crate::{
     model::AddAtmosphereModel,
     pipeline::*,
-    skybox::{AtmosphereSkyBoxMaterial, SkyBoxMaterial, ATMOSPHERE_SKYBOX_SHADER_HANDLE},
+    skybox::{AtmosphereSkyBoxMaterial, SkyBoxMaterial},
 };
 
 /// A `Plugin` that adds the prerequisites for a procedural sky.
@@ -23,12 +23,7 @@ pub struct AtmospherePlugin;
 
 impl Plugin for AtmospherePlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            ATMOSPHERE_SKYBOX_SHADER_HANDLE,
-            "shaders/skybox.wgsl",
-            Shader::from_wgsl
-        );
+        embedded_asset!(app, "src/", "shaders/skybox.wgsl");
 
         app.add_plugins(MaterialPlugin::<SkyBoxMaterial>::default());
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -143,7 +143,7 @@ fn atmosphere_remove(
     atmosphere_skyboxes: Query<Entity, With<AtmosphereSkyBox>>,
     mut atmosphere_cameras: RemovedComponents<AtmosphereCamera>,
 ) {
-    for camera in &mut atmosphere_cameras {
+    for camera in &mut atmosphere_cameras.read() {
         #[cfg(feature = "bevy/trace")]
         trace!("Removing skybox from camera entity (ID:{:?})", camera);
         let Ok(children) = parents.get(camera) else {

--- a/src/shaders/gradient.wgsl
+++ b/src/shaders/gradient.wgsl
@@ -6,8 +6,8 @@ struct Gradient {
 }
 
 fn render_gradient(r: vec3<f32>, g: Gradient) -> vec3<f32> {
-    let r = normalize(r);
-    let y = r.y;
+    let r_norm = normalize(r);
+    let y = r_norm.y;
 
     let p_sky = max(y, 0f);
     let p_horizon = 1f-abs(y);

--- a/src/shaders/nishita.wgsl
+++ b/src/shaders/nishita.wgsl
@@ -35,10 +35,10 @@ fn rsi(rd: vec3<f32>, r0: vec3<f32>, sr: f32) -> vec2<f32> {
     }
 }
 
-fn render_nishita(r: vec3<f32>, r0: vec3<f32>, p_sun: vec3<f32>, i_sun: f32, r_planet: f32, r_atmos: f32, k_rlh: vec3<f32>, k_mie: f32, sh_rlh: f32, sh_mie: f32, g: f32) -> vec3<f32> {
+fn render_nishita(r_full: vec3<f32>, r0: vec3<f32>, p_sun_full: vec3<f32>, i_sun: f32, r_planet: f32, r_atmos: f32, k_rlh: vec3<f32>, k_mie: f32, sh_rlh: f32, sh_mie: f32, g: f32) -> vec3<f32> {
     // Normalize the ray direction and sun position.
-    let r = normalize(r);
-    let p_sun = normalize(p_sun);
+    let r = normalize(r_full);
+    let p_sun = normalize(p_sun_full);
 
     // Calculate the step size of the primary ray.
     var p = rsi(r, r0, r_atmos);

--- a/src/shaders/skybox.wgsl
+++ b/src/shaders/skybox.wgsl
@@ -10,7 +10,7 @@ fn dither(frag_coord: vec2<f32>) -> vec3<f32> {
 }
 #endif
 
-#import bevy_pbr::mesh_vertex_output MeshVertexOutput
+#import bevy_pbr::forward_io::VertexOutput
 
 @group(1) @binding(0)
 var sky_texture: texture_cube<f32>;
@@ -19,7 +19,7 @@ var sky_sampler: sampler;
 
 @fragment
 fn fragment(
-    in: MeshVertexOutput
+    in: VertexOutput
 ) -> @location(0) vec4<f32> {
     let color = textureSample(sky_texture, sky_sampler, in.world_normal).xyz;
 #ifdef DITHER

--- a/src/skybox.rs
+++ b/src/skybox.rs
@@ -15,11 +15,11 @@ use bevy::{
 pub struct AtmosphereSkyBoxMaterial(pub Handle<SkyBoxMaterial>);
 
 /// The `Handle` for the shader for the [`SkyBoxMaterial`].
-pub const ATMOSPHERE_SKYBOX_SHADER_HANDLE: HandleUntyped =
-    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 4511926918914205353);
+pub const ATMOSPHERE_SKYBOX_SHADER_HANDLE: Handle<Shader> =
+    Handle::weak_from_u128(4511926918914205353);
 
 /// The `Material` that renders skyboxes.
-#[derive(AsBindGroup, TypeUuid, TypePath, Debug, Clone)]
+#[derive(AsBindGroup, TypeUuid, TypePath, Debug, Clone, Asset)]
 #[uuid = "b460ff90-0ee4-42df-875f-0a62ecd1301c"]
 #[bind_group_data(SkyBoxMaterialKey)]
 pub struct SkyBoxMaterial {
@@ -40,7 +40,7 @@ pub struct SkyBoxMaterialKey {
 
 impl Material for SkyBoxMaterial {
     fn fragment_shader() -> ShaderRef {
-        ATMOSPHERE_SKYBOX_SHADER_HANDLE.typed().into()
+        ATMOSPHERE_SKYBOX_SHADER_HANDLE.into()
     }
 
     fn specialize(

--- a/src/skybox.rs
+++ b/src/skybox.rs
@@ -1,6 +1,7 @@
 //! Provides types and data needed for rendering a skybox.
 
 use bevy::{
+    asset::AssetPath,
     pbr::{MaterialPipeline, MaterialPipelineKey},
     prelude::*,
     reflect::{TypePath, TypeUuid},
@@ -13,10 +14,6 @@ use bevy::{
 /// The `Handle` for the created [`SkyBoxMaterial`].
 #[derive(Resource)]
 pub struct AtmosphereSkyBoxMaterial(pub Handle<SkyBoxMaterial>);
-
-/// The `Handle` for the shader for the [`SkyBoxMaterial`].
-pub const ATMOSPHERE_SKYBOX_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(4511926918914205353);
 
 /// The `Material` that renders skyboxes.
 #[derive(AsBindGroup, TypeUuid, TypePath, Debug, Clone, Asset)]
@@ -40,7 +37,7 @@ pub struct SkyBoxMaterialKey {
 
 impl Material for SkyBoxMaterial {
     fn fragment_shader() -> ShaderRef {
-        ATMOSPHERE_SKYBOX_SHADER_HANDLE.into()
+        AssetPath::parse("embedded://bevy_atmosphere/shaders/skybox.wgsl").into()
     }
 
     fn specialize(


### PR DESCRIPTION
This PR updates the core plugin to Bevy 0.12. ~~Some examples are not compiling since they rely on the `bevy_spectator` plugin, which hasn't been updated yet.~~ 

UPDATE: I've now updated `bevy_spectator` to the latest version, and all the examples seem to build 