### PR TITLE
Rollback use of `embedded_asset!`

### DIFF
--- a/macros/src/model.rs
+++ b/macros/src/model.rs
@@ -49,6 +49,14 @@ pub fn derive_atmospheric(ast: syn::DeriveInput) -> Result<TokenStream> {
     let asset_path = manifest.get_path("bevy_asset");
     let ecs_path = manifest.get_path("bevy_ecs");
 
+    let id = {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        ast.ident.hash(&mut hasher);
+        hasher.finish()
+    };
+
     let mut shader_path = ShaderPathType::None;
     let mut binding_states: Vec<BindingState> = Vec::new();
     let mut binding_impls = Vec::new();
@@ -132,16 +140,22 @@ pub fn derive_atmospheric(ast: syn::DeriveInput) -> Result<TokenStream> {
                 asset_server.load(#s)
             }
         },
-        ShaderPathType::Internal(s) => {
-            quote! {
+        ShaderPathType::Internal(s) => quote! {
             {
+                use bevy::reflect::TypeUuid;
+                let handle: #asset_path::Handle<Shader> = #asset_path::Handle::weak_from_u128(#id as u128);
 
-                #asset_path::embedded_asset!(app, "src/", #s);
-                let asset_server = app.world.resource::<AssetServer>();
-                asset_server.load(format!("embedded://{}", #asset_path::embedded_path!("src/", #s).display()))
+                let internal_handle = handle.clone();
+                #asset_path::load_internal_asset!(
+                    app,
+                    internal_handle,
+                    concat!(env!("CARGO_MANIFEST_DIR"), "/src/", #s),
+                    Shader::from_wgsl
+                );
+
+                handle
             }
-            }
-        }
+        },
     };
 
     let fields = match &ast.data {

--- a/src/collection/gradient.rs
+++ b/src/collection/gradient.rs
@@ -6,7 +6,7 @@ use bevy::{prelude::*, render::render_resource::ShaderType};
 /// A simple gradient for creating a stylized environment.
 #[derive(Atmospheric, ShaderType, Reflect, Debug, Clone)]
 #[uniform(0, Gradient)]
-#[internal("../shaders/gradient.wgsl")]
+#[internal("shaders/gradient.wgsl")]
 pub struct Gradient {
     /// Sky Color (Default: `Color::rgb(0.29, 0.41, 0.50)`).
     /// <div style="background-color:rgb(29%, 41%, 50%); width: 10px; padding: 10px; border: 1px solid;"></div>

--- a/src/collection/nishita.rs
+++ b/src/collection/nishita.rs
@@ -6,7 +6,7 @@ use bevy::{prelude::*, render::render_resource::ShaderType};
 /// An atmospheric model that uses Rayleigh and Mie scattering to simulate a realistic sky.
 #[derive(Atmospheric, ShaderType, Reflect, Debug, Clone)]
 #[uniform(0, Nishita)]
-#[internal("../shaders/nishita.wgsl")]
+#[internal("shaders/nishita.wgsl")]
 pub struct Nishita {
     /// Ray Origin (Default: `(0.0, 6372e3, 0.0)`).
     ///

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,7 +1,7 @@
 //! Provides a `Plugin` for making skyboxes with procedural sky textures.
 
 use bevy::{
-    asset::embedded_asset,
+    asset::load_internal_asset,
     pbr::{NotShadowCaster, NotShadowReceiver},
     prelude::*,
     render::{
@@ -14,7 +14,7 @@ use bevy::{
 use crate::{
     model::AddAtmosphereModel,
     pipeline::*,
-    skybox::{AtmosphereSkyBoxMaterial, SkyBoxMaterial},
+    skybox::{AtmosphereSkyBoxMaterial, SkyBoxMaterial, ATMOSPHERE_SKYBOX_SHADER_HANDLE},
 };
 
 /// A `Plugin` that adds the prerequisites for a procedural sky.
@@ -23,7 +23,12 @@ pub struct AtmospherePlugin;
 
 impl Plugin for AtmospherePlugin {
     fn build(&self, app: &mut App) {
-        embedded_asset!(app, "src/", "shaders/skybox.wgsl");
+        load_internal_asset!(
+            app,
+            ATMOSPHERE_SKYBOX_SHADER_HANDLE,
+            "shaders/skybox.wgsl",
+            Shader::from_wgsl
+        );
 
         app.add_plugins(MaterialPlugin::<SkyBoxMaterial>::default());
 

--- a/src/skybox.rs
+++ b/src/skybox.rs
@@ -1,7 +1,6 @@
 //! Provides types and data needed for rendering a skybox.
 
 use bevy::{
-    asset::AssetPath,
     pbr::{MaterialPipeline, MaterialPipelineKey},
     prelude::*,
     reflect::{TypePath, TypeUuid},
@@ -14,6 +13,10 @@ use bevy::{
 /// The `Handle` for the created [`SkyBoxMaterial`].
 #[derive(Resource)]
 pub struct AtmosphereSkyBoxMaterial(pub Handle<SkyBoxMaterial>);
+
+/// The `Handle` for the shader for the [`SkyBoxMaterial`].
+pub const ATMOSPHERE_SKYBOX_SHADER_HANDLE: Handle<Shader> =
+    Handle::weak_from_u128(4511926918914205353);
 
 /// The `Material` that renders skyboxes.
 #[derive(AsBindGroup, TypeUuid, TypePath, Debug, Clone, Asset)]
@@ -37,7 +40,7 @@ pub struct SkyBoxMaterialKey {
 
 impl Material for SkyBoxMaterial {
     fn fragment_shader() -> ShaderRef {
-        AssetPath::parse("embedded://bevy_atmosphere/shaders/skybox.wgsl").into()
+        ATMOSPHERE_SKYBOX_SHADER_HANDLE.into()
     }
 
     fn specialize(


### PR DESCRIPTION
This PR attempts to fix the issue described in https://github.com/JonahPlusPlus/bevy_atmosphere/issues/64, by rollback the usage of `embedded_asset!` for embedding an asset in the binary