### PR TITLE
Update to Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_atmosphere"
 description = "A procedural sky plugin for bevy"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 authors = ["JonahPlusPlus <33059163+JonahPlusPlus@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ repository = "https://github.com/JonahPlusPlus/bevy_atmosphere"
 exclude = ["/assets/", "/examples/", "/.github/"]
 
 [dependencies]
-bevy = { version = "0.13", default-features = false, features = [
+bevy = { version = "0.14", default-features = false, features = [
   "bevy_asset",
   "bevy_render",
   "bevy_pbr",
@@ -20,8 +20,8 @@ bevy_atmosphere_macros = { path = "macros", version = "0.5" }
 cfg-if = "1.0"
 
 [dev-dependencies]
-bevy_spectator = "0.5"
-bevy = { version = "0.13", features = ["bevy_core_pipeline", "x11"] }
+bevy_spectator = "0.6"
+bevy = { version = "0.14", features = ["bevy_core_pipeline", "x11"] }
 
 [features]
 default = ["basic", "all_models"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For more information on the technicalities, you can check out the [technical doc
 
 | bevy | bevy_atmosphere |
 |------|-----------------|
+| 0.14 | 0.10            |
 | 0.13 | 0.9             |
 | 0.12 | 0.8             |
 | 0.11 | 0.7             |

--- a/examples/cycle.rs
+++ b/examples/cycle.rs
@@ -65,14 +65,14 @@ fn setup_environment(
     // Simple transform shape just for reference
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::default()),
-        material: materials.add(StandardMaterial::from(Color::rgb(0.8, 0.8, 0.8))),
+        material: materials.add(StandardMaterial::from(Color::srgb(0.8, 0.8, 0.8))),
         ..Default::default()
     });
 
     // X axis
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::new(0.5, 0.5, 0.5)),
-        material: materials.add(StandardMaterial::from(Color::rgb(0.8, 0.0, 0.0))),
+        material: materials.add(StandardMaterial::from(Color::srgb(0.8, 0.0, 0.0))),
         transform: Transform::from_xyz(1., 0., 0.),
         ..Default::default()
     });
@@ -80,7 +80,7 @@ fn setup_environment(
     // Y axis
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::new(0.5, 0.5, 0.5)),
-        material: materials.add(StandardMaterial::from(Color::rgb(0.0, 0.8, 0.0))),
+        material: materials.add(StandardMaterial::from(Color::srgb(0.0, 0.8, 0.0))),
         transform: Transform::from_xyz(0., 1., 0.),
         ..Default::default()
     });
@@ -88,7 +88,7 @@ fn setup_environment(
     // Z axis
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::new(0.5, 0.5, 0.5)),
-        material: materials.add(StandardMaterial::from(Color::rgb(0.0, 0.0, 0.8))),
+        material: materials.add(StandardMaterial::from(Color::srgb(0.0, 0.0, 0.8))),
         transform: Transform::from_xyz(0., 0., 1.),
         ..Default::default()
     });

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -1,3 +1,4 @@
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_atmosphere::prelude::*;
 use bevy_spectator::{Spectator, SpectatorPlugin};
@@ -27,58 +28,58 @@ fn change_gradient(mut commands: Commands, keys: Res<ButtonInput<KeyCode>>) {
     } else if keys.just_pressed(KeyCode::Digit2) {
         info!("Changed to Atmosphere Preset 2 (Cotton Candy)");
         commands.insert_resource(AtmosphereModel::new(Gradient {
-            ground: Color::rgb(1.0, 0.5, 0.75),
-            horizon: Color::WHITE,
-            sky: Color::rgb(0.5, 0.75, 1.0),
+            ground: Color::srgb(1.0, 0.5, 0.75).into(),
+            horizon: LinearRgba::WHITE,
+            sky: Color::srgb(0.5, 0.75, 1.0).into(),
         }));
     } else if keys.just_pressed(KeyCode::Digit3) {
         info!("Changed to Atmosphere Preset 3 (80's Sunset)");
         commands.insert_resource(AtmosphereModel::new(Gradient {
-            sky: Color::PURPLE,
-            horizon: Color::PINK,
-            ground: Color::ORANGE,
+            sky: palettes::css::PURPLE.into(),
+            horizon: palettes::css::PINK.into(),
+            ground: palettes::css::ORANGE.into(),
         }));
     } else if keys.just_pressed(KeyCode::Digit4) {
         info!("Changed to Atmosphere Preset 4 (Winter)");
         commands.insert_resource(AtmosphereModel::new(Gradient {
-            ground: Color::rgb(0.0, 0.1, 0.2),
-            horizon: Color::rgb(0.3, 0.4, 0.5),
-            sky: Color::rgb(0.7, 0.8, 0.9),
+            ground: Color::srgb(0.0, 0.1, 0.2).into(),
+            horizon: Color::srgb(0.3, 0.4, 0.5).into(),
+            sky: Color::srgb(0.7, 0.8, 0.9).into(),
         }));
     } else if keys.just_pressed(KeyCode::Digit5) {
         info!("Changed to Atmosphere Preset 5 (Nether)");
         commands.insert_resource(AtmosphereModel::new(Gradient {
-            ground: Color::BLACK,
-            horizon: Color::rgb(0.2, 0.0, 0.0),
-            sky: Color::rgb(0.5, 0.1, 0.0),
+            ground: LinearRgba::BLACK,
+            horizon: Color::srgb(0.2, 0.0, 0.0).into(),
+            sky: Color::srgb(0.5, 0.1, 0.0).into(),
         }));
     } else if keys.just_pressed(KeyCode::Digit6) {
         info!("Changed to Atmosphere Preset 6 (Golden)");
         commands.insert_resource(AtmosphereModel::new(Gradient {
-            ground: Color::ORANGE_RED,
-            horizon: Color::ORANGE,
-            sky: Color::GOLD,
+            ground: palettes::css::ORANGE_RED.into(),
+            horizon: palettes::css::ORANGE.into(),
+            sky: palettes::css::GOLD.into(),
         }));
     } else if keys.just_pressed(KeyCode::Digit7) {
         info!("Changed to Atmosphere Preset 7 (Noir)");
         commands.insert_resource(AtmosphereModel::new(Gradient {
-            ground: Color::BLACK,
-            horizon: Color::BLACK,
-            sky: Color::WHITE,
+            ground: LinearRgba::BLACK,
+            horizon: LinearRgba::BLACK,
+            sky: LinearRgba::WHITE,
         }));
     } else if keys.just_pressed(KeyCode::Digit8) {
         info!("Changed to Atmosphere Preset 8 (Midnight)");
         commands.insert_resource(AtmosphereModel::new(Gradient {
-            ground: Color::BLACK,
-            horizon: Color::BLACK,
-            sky: Color::MIDNIGHT_BLUE,
+            ground: LinearRgba::BLACK,
+            horizon: LinearRgba::BLACK,
+            sky: palettes::css::MIDNIGHT_BLUE.into(),
         }));
     } else if keys.just_pressed(KeyCode::Digit9) {
         info!("Changed to Atmosphere Preset 9 (Greenery)");
         commands.insert_resource(AtmosphereModel::new(Gradient {
-            ground: Color::rgb(0.1, 0.2, 0.0),
-            horizon: Color::rgb(0.3, 0.4, 0.1),
-            sky: Color::rgb(0.6, 0.8, 0.2),
+            ground: Color::srgb(0.1, 0.2, 0.0).into(),
+            horizon: Color::srgb(0.3, 0.4, 0.1).into(),
+            sky: Color::srgb(0.6, 0.8, 0.2).into(),
         }));
     } else if keys.just_pressed(KeyCode::Digit0) {
         info!("Reset Atmosphere to Default");

--- a/examples/splitscreen.rs
+++ b/examples/splitscreen.rs
@@ -37,8 +37,8 @@ fn setup(
 ) {
     // Plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Plane3d::new(Vec3::Y).mesh().size(100.0, 100.0)),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
+        mesh: meshes.add(Plane3d::default().mesh().size(100.0, 100.0)),
+        material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
         ..default()
     });
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro-crate = "3.1"
-bevy_macro_utils = "0.13"
+bevy_macro_utils = "0.14"
 
 syn = "2.0"
 proc-macro2 = "1.0"

--- a/src/collection/gradient.rs
+++ b/src/collection/gradient.rs
@@ -8,32 +8,32 @@ use bevy::{prelude::*, render::render_resource::ShaderType};
 #[uniform(0, Gradient)]
 #[internal("shaders/gradient.wgsl")]
 pub struct Gradient {
-    /// Sky Color (Default: `Color::rgb(0.29, 0.41, 0.50)`).
+    /// Sky Color (Default: `Color::srgb(0.29, 0.41, 0.50)`).
     /// <div style="background-color:rgb(29%, 41%, 50%); width: 10px; padding: 10px; border: 1px solid;"></div>
     ///
     ///
     /// The color of the top.
-    pub sky: Color,
-    /// Horizon Color (Default: `Color::rgb(0.48, 0.62, 0.69)`).
+    pub sky: LinearRgba,
+    /// Horizon Color (Default: `Color::srgb(0.48, 0.62, 0.69)`).
     /// <div style="background-color:rgb(48%, 62%, 69%); width: 10px; padding: 10px; border: 1px solid;"></div>
     ///
     ///
     /// The color of the sides.
-    pub horizon: Color,
-    /// Ground Color (Default: `Color::rgb(0.71, 0.69, 0.57)`).
+    pub horizon: LinearRgba,
+    /// Ground Color (Default: `Color::srgb(0.71, 0.69, 0.57)`).
     /// <div style="background-color:rgb(71%, 69%, 57%); width: 10px; padding: 10px; border: 1px solid;"></div>
     ///
     ///
     /// The color of the bottom.
-    pub ground: Color,
+    pub ground: LinearRgba,
 }
 
 impl Default for Gradient {
     fn default() -> Self {
         Self {
-            sky: Color::rgb(0.29, 0.41, 0.50),
-            horizon: Color::rgb(0.48, 0.62, 0.69),
-            ground: Color::rgb(0.71, 0.69, 0.57),
+            sky: Color::srgb(0.29, 0.41, 0.50).into(),
+            horizon: Color::srgb(0.48, 0.62, 0.69).into(),
+            ground: Color::srgb(0.71, 0.69, 0.57).into(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! }
 //!
 //! fn write_gradient(mut atmosphere: AtmosphereMut<Gradient>) {
-//!     atmosphere.horizon = Color::RED;
+//!     atmosphere.horizon = LinearRgba::RED;
 //! }
 //!
 //! fn check_model(atmosphere: Res<AtmosphereModel>) {

--- a/src/model.rs
+++ b/src/model.rs
@@ -38,7 +38,7 @@ use bevy::{
         render_asset::RenderAssets,
         render_resource::{BindGroup, BindGroupLayout, CachedComputePipelineId},
         renderer::RenderDevice,
-        texture::FallbackImage,
+        texture::{FallbackImage, GpuImage},
     },
 };
 
@@ -55,7 +55,7 @@ pub trait Atmospheric: Send + Sync + Reflect + Any + 'static {
         &self,
         layout: &BindGroupLayout,
         render_device: &RenderDevice,
-        images: &RenderAssets<Image>,
+        images: &RenderAssets<GpuImage>,
         fallback_image: &FallbackImage,
     ) -> BindGroup;
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -37,18 +37,18 @@ impl Plugin for AtmospherePlugin {
 
         {
             let image_handle = {
-                let image = app.world.get_resource::<AtmosphereImage>().expect("`AtmosphereImage` missing! If the `procedural` feature is disabled, add the resource before `AtmospherePlugin`");
+                let image = app.world().get_resource::<AtmosphereImage>().expect("`AtmosphereImage` missing! If the `procedural` feature is disabled, add the resource before `AtmospherePlugin`");
                 image.handle.clone()
             };
 
             let settings = {
                 let settings = app
-                    .world
+                    .world()
                     .get_resource::<crate::settings::AtmosphereSettings>();
                 settings.copied().unwrap_or_default()
             };
 
-            let mut material_assets = app.world.resource_mut::<Assets<SkyBoxMaterial>>();
+            let mut material_assets = app.world_mut().resource_mut::<Assets<SkyBoxMaterial>>();
             let material = material_assets.add(SkyBoxMaterial {
                 sky_texture: image_handle,
                 #[cfg(feature = "dithering")]
@@ -84,7 +84,7 @@ impl Plugin for AtmospherePlugin {
 /// When added, a skybox will be created as a child.
 /// When removed, that skybox will also be removed.
 /// This behaviour can be disabled by turning off the "detection" feature.
-#[derive(Component, Default, Debug, Clone, Copy)]
+#[derive(Component, Default, Debug, Clone)]
 pub struct AtmosphereCamera {
     /// Controls whether or not the skybox will be seen only on certain render layers.
     pub render_layers: Option<RenderLayers>,
@@ -129,7 +129,7 @@ fn atmosphere_insert(
                     render_layers: Some(render_layers),
                 } = atmosphere_camera
                 {
-                    child.insert(*render_layers);
+                    child.insert(render_layers.clone());
                 }
             });
     }

--- a/src/skybox.rs
+++ b/src/skybox.rs
@@ -5,7 +5,7 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::{
-        mesh::{Indices, Mesh, MeshVertexBufferLayout, PrimitiveTopology},
+        mesh::{Indices, Mesh, MeshVertexBufferLayoutRef, PrimitiveTopology},
         render_resource::{AsBindGroup, RenderPipelineDescriptor, ShaderDefVal, ShaderRef},
     },
 };
@@ -45,7 +45,7 @@ impl Material for SkyBoxMaterial {
     fn specialize(
         _pipeline: &MaterialPipeline<Self>,
         descriptor: &mut RenderPipelineDescriptor,
-        _layout: &MeshVertexBufferLayout,
+        _layout: &MeshVertexBufferLayoutRef,
         key: MaterialPipelineKey<Self>,
     ) -> Result<(), bevy::render::render_resource::SpecializedMeshPipelineError> {
         #[cfg(feature = "dithering")]


### PR DESCRIPTION
The examples depend on new version of `bevy_spectator` to be released first. PR with update submitted at https://github.com/JonahPlusPlus/bevy_spectator/pull/13.

Most changes were related either to `world()`/`world_mut()` API change, or a rename of `Image` to `GpuImage`. The shader uniform now uses `LinearRgba` types for colors, and all relevant usages of `Color::srgb` are now `into()` converted into it.