### PR TITLE
Update to Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,3 @@ required-features = ["default", "bevy/trace", "bevy/trace_chrome"]
 name = "splitscreen"
 path = "examples/splitscreen.rs"
 required-features = ["default"]
-
-[patch.crates-io]
-# TODO: Temporary patch for dev-dep, remove when upstream updates
-bevy_spectator = { git = "https://github.com/ptsd/bevy_spectator.git", branch = "bevy-0.15" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/JonahPlusPlus/bevy_atmosphere"
 exclude = ["/assets/", "/examples/", "/.github/"]
 
 [dependencies]
-bevy = { version = "0.15.0-rc.3", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
   "bevy_asset",
   "bevy_render",
   "bevy_pbr",
@@ -21,7 +21,7 @@ cfg-if = "1.0"
 
 [dev-dependencies]
 bevy_spectator = "0.7"
-bevy = { version = "0.15.0-rc.3", features = ["bevy_core_pipeline", "x11"] }
+bevy = { version = "0.15", features = ["bevy_core_pipeline", "x11"] }
 
 [features]
 default = ["basic", "all_models"]
@@ -69,6 +69,11 @@ required-features = ["default"]
 name = "settings"
 path = "examples/settings.rs"
 required-features = ["default"]
+
+[[example]]
+name = "settings_trace"
+path = "examples/settings.rs"
+required-features = ["default", "bevy/trace", "bevy/trace_chrome"]
 
 [[example]]
 name = "splitscreen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ repository = "https://github.com/JonahPlusPlus/bevy_atmosphere"
 exclude = ["/assets/", "/examples/", "/.github/"]
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15.0-rc.3", default-features = false, features = [
   "bevy_asset",
   "bevy_render",
   "bevy_pbr",
 ] }
-bevy_atmosphere_macros = { path = "macros", version = "0.6" }
+bevy_atmosphere_macros = { path = "macros", version = "0.7" }
 cfg-if = "1.0"
 
 [dev-dependencies]
-bevy_spectator = "0.6"
-bevy = { version = "0.14", features = ["bevy_core_pipeline", "x11"] }
+bevy_spectator = "0.7"
+bevy = { version = "0.15.0-rc.3", features = ["bevy_core_pipeline", "x11"] }
 
 [features]
 default = ["basic", "all_models"]
@@ -74,3 +74,7 @@ required-features = ["default"]
 name = "splitscreen"
 path = "examples/splitscreen.rs"
 required-features = ["default"]
+
+[patch.crates-io]
+# TODO: Temporary patch for dev-dep, remove when upstream updates
+bevy_spectator = { git = "https://github.com/ptsd/bevy_spectator.git", branch = "bevy-0.15" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bevy = { version = "0.15", default-features = false, features = [
   "bevy_asset",
   "bevy_render",
   "bevy_pbr",
+  "png", # Enable temporary due to 0.15 bug: https://github.com/bevyengine/bevy/issues/16563
 ] }
 bevy_atmosphere_macros = { path = "macros", version = "0.7" }
 cfg-if = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,11 +72,6 @@ path = "examples/settings.rs"
 required-features = ["default"]
 
 [[example]]
-name = "settings_trace"
-path = "examples/settings.rs"
-required-features = ["default", "bevy/trace", "bevy/trace_chrome"]
-
-[[example]]
 name = "splitscreen"
 path = "examples/splitscreen.rs"
 required-features = ["default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bevy = { version = "0.15", default-features = false, features = [
   "bevy_asset",
   "bevy_render",
   "bevy_pbr",
-  "png", # Enable temporary due to 0.15 bug: https://github.com/bevyengine/bevy/issues/16563
+  "png",         # Enable temporary due to 0.15 bug: https://github.com/bevyengine/bevy/issues/16563
 ] }
 bevy_atmosphere_macros = { path = "macros", version = "0.7" }
 cfg-if = "1.0"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For more information on the technicalities, you can check out the [technical doc
 
 | bevy | bevy_atmosphere |
 |------|-----------------|
+| 0.15 | 0.11            |
 | 0.14 | 0.10            |
 | 0.13 | 0.9             |
 | 0.12 | 0.8             |

--- a/deny.toml
+++ b/deny.toml
@@ -1,11 +1,16 @@
-[advisories]
-unmaintained = "deny"
-yanked = "deny"
-notice = "deny"
-
 [licenses]
-copyleft = "deny"
-allow-osi-fsf-free = "either"
+allow = [
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CC0-1.0",
+  "ISC",
+  "MIT-0",
+  "MIT",
+  "Unicode-3.0",
+  "Zlib",
+]
 
 [[licenses.clarify]]
 name = "stretch"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -10,5 +10,5 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn((Camera3dBundle::default(), AtmosphereCamera::default()));
+    commands.spawn((Camera3d::default(), AtmosphereCamera::default()));
 }

--- a/examples/cycle.rs
+++ b/examples/cycle.rs
@@ -4,7 +4,6 @@ use bevy_spectator::{Spectator, SpectatorPlugin};
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .insert_resource(AtmosphereModel::default()) // Default Atmosphere material, we can edit it to simulate another planet
         .insert_resource(CycleTimer(Timer::new(
             bevy::utils::Duration::from_millis(50), // Update our atmosphere every 50ms (in a real game, this would be much slower, but for the sake of an example we use a faster update)
@@ -38,7 +37,7 @@ fn daylight_cycle(
     timer.0.tick(time.delta());
 
     if timer.0.finished() {
-        let t = time.elapsed_seconds_wrapped() / 2.0;
+        let t = time.elapsed_secs_wrapped() / 2.0;
         atmosphere.sun_position = Vec3::new(0., t.sin(), t.cos());
 
         if let Some((mut light_trans, mut directional)) = query.single_mut().into() {
@@ -56,49 +55,42 @@ fn setup_environment(
 ) {
     // Our Sun
     commands.spawn((
-        DirectionalLightBundle {
-            ..Default::default()
-        },
+        DirectionalLight::default(),
         Sun, // Marks the light as Sun
     ));
 
     // Simple transform shape just for reference
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::default()),
-        material: materials.add(StandardMaterial::from(Color::srgb(0.8, 0.8, 0.8))),
-        ..Default::default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(StandardMaterial::from(Color::srgb(0.8, 0.8, 0.8)))),
+    ));
 
     // X axis
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::new(0.5, 0.5, 0.5)),
-        material: materials.add(StandardMaterial::from(Color::srgb(0.8, 0.0, 0.0))),
-        transform: Transform::from_xyz(1., 0., 0.),
-        ..Default::default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(0.5, 0.5, 0.5))),
+        MeshMaterial3d(materials.add(StandardMaterial::from(Color::srgb(0.8, 0.0, 0.0)))),
+        Transform::from_xyz(1., 0., 0.),
+    ));
 
     // Y axis
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::new(0.5, 0.5, 0.5)),
-        material: materials.add(StandardMaterial::from(Color::srgb(0.0, 0.8, 0.0))),
-        transform: Transform::from_xyz(0., 1., 0.),
-        ..Default::default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(0.5, 0.5, 0.5))),
+        MeshMaterial3d(materials.add(StandardMaterial::from(Color::srgb(0.0, 0.8, 0.0)))),
+        Transform::from_xyz(0., 1., 0.),
+    ));
 
     // Z axis
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::new(0.5, 0.5, 0.5)),
-        material: materials.add(StandardMaterial::from(Color::srgb(0.0, 0.0, 0.8))),
-        transform: Transform::from_xyz(0., 0., 1.),
-        ..Default::default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(0.5, 0.5, 0.5))),
+        MeshMaterial3d(materials.add(StandardMaterial::from(Color::srgb(0.0, 0.0, 0.8)))),
+        Transform::from_xyz(0., 0., 1.),
+    ));
 
     // Spawn our camera
     commands.spawn((
-        Camera3dBundle {
-            transform: Transform::from_xyz(5., 0., 5.),
-            ..default()
-        },
+        Camera3d::default(),
+        Transform::from_xyz(5., 0., 5.),
+        Msaa::Sample4,
         AtmosphereCamera::default(), // Marks camera as having a skybox, by default it doesn't specify the render layers the skybox can be seen on
         Spectator,                   // Marks camera as spectator (specific to bevy_spectator)
     ));

--- a/examples/detection.rs
+++ b/examples/detection.rs
@@ -14,7 +14,7 @@ fn main() {
 struct PrimaryCamera;
 
 fn setup(mut commands: Commands) {
-    commands.spawn((Camera3dBundle::default(), PrimaryCamera));
+    commands.spawn((Camera3d::default(), PrimaryCamera));
 }
 
 fn update(

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -14,11 +14,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn((
-        Camera3d::default(),
-        AtmosphereCamera::default(),
-        Spectator,
-    ));
+    commands.spawn((Camera3d::default(), AtmosphereCamera::default(), Spectator));
 }
 
 fn change_gradient(mut commands: Commands, keys: Res<ButtonInput<KeyCode>>) {

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -15,7 +15,7 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     commands.spawn((
-        Camera3dBundle::default(),
+        Camera3d::default(),
         AtmosphereCamera::default(),
         Spectator,
     ));

--- a/examples/models.rs
+++ b/examples/models.rs
@@ -13,11 +13,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn((
-        Camera3d::default(),
-        AtmosphereCamera::default(),
-        Spectator,
-    ));
+    commands.spawn((Camera3d::default(), AtmosphereCamera::default(), Spectator));
 }
 
 fn change_model(mut commands: Commands, keys: Res<ButtonInput<KeyCode>>) {

--- a/examples/models.rs
+++ b/examples/models.rs
@@ -14,7 +14,7 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     commands.spawn((
-        Camera3dBundle::default(),
+        Camera3d::default(),
         AtmosphereCamera::default(),
         Spectator,
     ));

--- a/examples/nishita.rs
+++ b/examples/nishita.rs
@@ -12,11 +12,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn((
-        Camera3d::default(),
-        AtmosphereCamera::default(),
-        Spectator,
-    ));
+    commands.spawn((Camera3d::default(), AtmosphereCamera::default(), Spectator));
 }
 
 fn change_nishita(mut commands: Commands, keys: Res<ButtonInput<KeyCode>>) {

--- a/examples/nishita.rs
+++ b/examples/nishita.rs
@@ -13,7 +13,7 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     commands.spawn((
-        Camera3dBundle::default(),
+        Camera3d::default(),
         AtmosphereCamera::default(),
         Spectator,
     ));

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -16,11 +16,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn((
-        Camera3d::default(),
-        AtmosphereCamera::default(),
-        Spectator,
-    ));
+    commands.spawn((Camera3d::default(), AtmosphereCamera::default(), Spectator));
 }
 
 // Change the resolution when the user presses a number key
@@ -30,8 +26,6 @@ fn change_resolution(
     keys: Res<ButtonInput<KeyCode>>,
 ) {
     if keys.just_pressed(KeyCode::Space) {
-        #[cfg(feature = "bevy/trace")]
-        // enabling "bevy/trace" (via "bevy/trace_chrome" or "bevy/trace_tracy") allows you to debug bevy_atmosphere
         let _change_dithering_executed_span =
             info_span!("executed", name = "settings::change_dithering").entered();
         if let Some(mut settings) = settings {
@@ -69,8 +63,6 @@ fn change_resolution(
 
 // A separate `change` fn makes it easier to debug in tracy.
 fn change(mut commands: Commands, settings: Option<ResMut<AtmosphereSettings>>, resolution: u32) {
-    #[cfg(feature = "bevy/trace")]
-    // enabling "bevy/trace" (via "bevy/trace_chrome" or "bevy/trace_tracy") allows you to debug bevy_atmosphere
     let _change_resolution_executed_span =
         info_span!("executed", name = "settings::change_resolution").entered();
     if let Some(mut settings) = settings {

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -17,7 +17,7 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     commands.spawn((
-        Camera3dBundle::default(),
+        Camera3d::default(),
         AtmosphereCamera::default(),
         Spectator,
     ));

--- a/examples/splitscreen.rs
+++ b/examples/splitscreen.rs
@@ -51,7 +51,7 @@ fn setup(
             0.0,
             1.0,
             -std::f32::consts::FRAC_PI_4,
-        ))
+        )),
     ));
 
     // Spawn left screen camera and make it the default spectator

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro-crate = "3.1"
-bevy_macro_utils = "0.15.0-rc.3"
+bevy_macro_utils = "0.15"
 
 syn = "2.0"
 proc-macro2 = "1.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_atmosphere_macros"
 description = "Proc macros for bevy_atmosphere"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["JonahPlusPlus <33059163+JonahPlusPlus@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro-crate = "3.1"
-bevy_macro_utils = "0.14"
+bevy_macro_utils = "0.15.0-rc.3"
 
 syn = "2.0"
 proc-macro2 = "1.0"

--- a/macros/src/model.rs
+++ b/macros/src/model.rs
@@ -467,6 +467,7 @@ pub fn derive_atmospheric(ast: syn::DeriveInput) -> Result<TokenStream> {
                     shader: handle,
                     shader_defs: vec![],
                     entry_point: Cow::from("main"),
+                    zero_initialize_workgroup_memory: true,
                 });
 
                 let id = TypeId::of::<Self>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! }
 //!
 //! fn setup(mut commands: Commands) {
-//!     commands.spawn((Camera3dBundle::default(), AtmosphereCamera::default()));
+//!     commands.spawn((Camera3d::default(), AtmosphereCamera::default()));
 //! }
 //! ```
 //!

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -341,10 +341,20 @@ fn prepare_atmosphere_resources(
         atmosphere_image.array_view = Some(view);
         update();
         #[cfg(feature = "bevy/trace")]
-        trace!(
-            "Created new 2D array texture view from atmosphere texture of size {:?}",
-            &gpu_images[&atmosphere_image.handle].size
-        );
+        {
+            if let Some(image) = gpu_images.get(&atmosphere_image.handle) {
+                trace!(
+                    "Created new 2D array texture view from atmosphere texture of size {:?}",
+                    image.size
+                );
+            } else {
+                trace!(
+                    "Failed to find gpu_image for {:?}",
+                    &atmosphere_image.handle
+                );
+            }
+        }
+
     }
 
     if atmosphere.is_changed() {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -165,7 +165,6 @@ fn atmosphere_settings_changed(
 ) {
     if let Some(settings) = settings {
         if settings.is_changed() {
-            #[cfg(feature = "bevy/trace")]
             let _atmosphere_settings_changed_executed_span = info_span!(
                 "executed",
                 name = "bevy_atmosphere::pipeline::atmosphere_settings_changed"
@@ -186,14 +185,12 @@ fn atmosphere_settings_changed(
                     skybox_material.dithering = settings.dithering;
                 }
                 atmosphere_image.array_view = None; // drop the previous texture view
-                #[cfg(feature = "bevy/trace")]
                 trace!("Resized image to {:?}", size);
             }
         }
         *settings_existed = true;
     } else {
         if *settings_existed {
-            #[cfg(feature = "bevy/trace")]
             let _atmosphere_settings_changed_executed_span = info_span!(
                 "executed",
                 name = "bevy_atmosphere::pipeline::atmosphere_settings_changed"
@@ -212,7 +209,6 @@ fn atmosphere_settings_changed(
                 image.resize(size);
                 let _ = material_assets.get_mut(&material.0); // `get_mut` tells the material to update
                 atmosphere_image.array_view = None; // drop the previous texture view
-                #[cfg(feature = "bevy/trace")]
                 trace!("Resized image to {:?}", size);
             }
         }
@@ -330,7 +326,6 @@ fn prepare_atmosphere_resources(
     let mut update = || update_events.send(AtmosphereUpdateEvent);
 
     if atmosphere_image.array_view.is_none() {
-        #[cfg(feature = "bevy/trace")]
         let _prepare_atmosphere_assets_executed_span = info_span!(
             "executed",
             name = "bevy_atmosphere::pipeline::prepare_atmosphere_assets"
@@ -340,21 +335,17 @@ fn prepare_atmosphere_resources(
         let view = texture.create_view(&ATMOSPHERE_ARRAY_TEXTURE_VIEW_DESCRIPTOR);
         atmosphere_image.array_view = Some(view);
         update();
-        #[cfg(feature = "bevy/trace")]
-        {
-            if let Some(image) = gpu_images.get(&atmosphere_image.handle) {
-                trace!(
-                    "Created new 2D array texture view from atmosphere texture of size {:?}",
-                    image.size
-                );
-            } else {
-                trace!(
-                    "Failed to find gpu_image for {:?}",
-                    &atmosphere_image.handle
-                );
-            }
+        if let Some(image) = gpu_images.get(&atmosphere_image.handle) {
+            trace!(
+                "Created new 2D array texture view from atmosphere texture of size {:?}",
+                image.size
+            );
+        } else {
+            trace!(
+                "Failed to find gpu_image for {:?}",
+                &atmosphere_image.handle
+            );
         }
-
     }
 
     if atmosphere.is_changed() {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -105,7 +105,6 @@ fn atmosphere_insert(
     atmosphere_cameras: Query<(Entity, &Projection, &AtmosphereCamera), Added<AtmosphereCamera>>,
 ) {
     for (camera, projection, atmosphere_camera) in &atmosphere_cameras {
-        #[cfg(feature = "bevy/trace")]
         trace!("Adding skybox to camera entity (ID:{:?})", camera);
         commands
             .entity(camera)
@@ -138,7 +137,6 @@ fn atmosphere_remove(
     mut atmosphere_cameras: RemovedComponents<AtmosphereCamera>,
 ) {
     for camera in &mut atmosphere_cameras.read() {
-        #[cfg(feature = "bevy/trace")]
         trace!("Removing skybox from camera entity (ID:{:?})", camera);
         let Ok(children) = parents.get(camera) else {
             error!("Failed to get skybox children entities from camera entity.");
@@ -147,7 +145,6 @@ fn atmosphere_remove(
 
         for child in children {
             let Ok(skybox_entity) = atmosphere_skyboxes.get(*child) else {
-                #[cfg(feature = "bevy/trace")]
                 trace!("Child wasn't found in skybox entities.");
                 continue;
             };

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -109,17 +109,13 @@ fn atmosphere_insert(
         trace!("Adding skybox to camera entity (ID:{:?})", camera);
         commands
             .entity(camera)
-            .insert(VisibilityBundle {
-                visibility: Visibility::Visible,
-                ..default()
-            })
+            .insert((
+                Visibility::Visible,
+            ))
             .with_children(|c| {
                 let mut child = c.spawn((
-                    MaterialMeshBundle {
-                        mesh: mesh_assets.add(crate::skybox::mesh(projection.far())),
-                        material: material.0.clone(),
-                        ..default()
-                    },
+                    Mesh3d(mesh_assets.add(crate::skybox::mesh(projection.far()))),
+                    MeshMaterial3d(material.0.clone()),
                     AtmosphereSkyBox,
                     NotShadowCaster,
                     NotShadowReceiver,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -109,9 +109,7 @@ fn atmosphere_insert(
         trace!("Adding skybox to camera entity (ID:{:?})", camera);
         commands
             .entity(camera)
-            .insert((
-                Visibility::Visible,
-            ))
+            .insert(Visibility::Visible)
             .with_children(|c| {
                 let mut child = c.spawn((
                     Mesh3d(mesh_assets.add(crate::skybox::mesh(projection.far()))),

--- a/src/system_param.rs
+++ b/src/system_param.rs
@@ -21,7 +21,7 @@ pub struct Atmosphere<'w, T: Atmospheric> {
 // SAFETY: Res only reads a single World resource
 unsafe impl<T: Atmospheric> ReadOnlySystemParam for Atmosphere<'_, T> {}
 
-impl<'w, T: Atmospheric> Deref for Atmosphere<'w, T> {
+impl<T: Atmospheric> Deref for Atmosphere<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -63,7 +63,7 @@ pub struct AtmosphereMut<'w, T: Atmospheric> {
     value: &'w mut T,
 }
 
-impl<'w, T: Atmospheric> Deref for AtmosphereMut<'w, T> {
+impl<T: Atmospheric> Deref for AtmosphereMut<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -71,7 +71,7 @@ impl<'w, T: Atmospheric> Deref for AtmosphereMut<'w, T> {
     }
 }
 
-impl<'w, T: Atmospheric> DerefMut for AtmosphereMut<'w, T> {
+impl<T: Atmospheric> DerefMut for AtmosphereMut<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.value
     }


### PR DESCRIPTION
Hi, thanks for this super useful package 😄.

This is basically just deps and deprecation changes but I needed it so might as well save you the hassle 👍 

Todo:
- [x] Update to non-rc deps for bevy when available
- [x] Remove `bevy_spectator` crates.io patch when upstream updates (see: https://github.com/JonahPlusPlus/bevy_spectator/pull/14)