### PR TITLE
Allow changing the created skybox size when using `detection`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,13 +52,28 @@
 //!
 //! Use the [`AtmosphereSettings`](crate::settings::AtmosphereSettings) resource to change how the sky is rendered.
 //! ```no_run
-//! # use bevy_atmosphere::settings::AtmosphereSettings;
+//! # use bevy::utils::default;
+//! use bevy_atmosphere::settings::AtmosphereSettings;
 //! # let _ =
 //! AtmosphereSettings {
 //!     // changes the resolution (should be a multiple of 8)
 //!     resolution: 1024,
 //!     // turns off dithering
 //!     dithering: false,
+//!     ..default()
+//! }
+//! # ;
+//! ```
+//!
+//! When using the `detection` feature, you can use [`SkyboxCreationMode`](crate::settings::SkyboxCreationMode) to control the size of the generated skybox.
+//! ```no_run
+//! # use bevy::utils::default;
+//! use bevy_atmosphere::settings::{AtmosphereSettings, SkyboxCreationMode};
+//! # let _ =
+//! AtmosphereSettings {
+//!     // Will use the camera projections `far` value or `1000.0` as a fallback
+//!     skybox_creation_mode: SkyboxCreationMode::FromProjectionFarWithFallback(1000.0),
+//!     ..default()
 //! }
 //! # ;
 //! ```

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,6 +2,23 @@
 
 use bevy::{prelude::Resource, render::extract_resource::ExtractResource};
 
+/// Available methods for determining the size of the auto created skybox
+#[cfg(feature = "detection")]
+#[derive(Debug, Clone, Copy)]
+pub enum SkyboxCreationMode {
+    /// Uses the camera projection `far` value or the specified fallback if `far` is `None`.
+    FromProjectionFarWithFallback(f32),
+    /// Ignores any camera projection `far` value and always uses the specified value.
+    FromSpecifiedFar(f32),
+}
+
+#[cfg(feature = "detection")]
+impl Default for SkyboxCreationMode {
+    fn default() -> Self {
+        Self::FromProjectionFarWithFallback(1000.0)
+    }
+}
+
 /// Provides settings for how the sky is rendered.
 #[derive(Resource, ExtractResource, Debug, Clone, Copy)]
 pub struct AtmosphereSettings {
@@ -16,6 +33,13 @@ pub struct AtmosphereSettings {
     /// This option can be removed by disabling the "dithering" feature
     #[cfg(feature = "dithering")]
     pub dithering: bool,
+    /// Method used to determine the size of the auto created skybox.
+    ///
+    /// See [`SkyboxCreationMode`]
+    ///
+    /// Default: `FromProjectionFarWithFallback(1000.0)`.
+    #[cfg(feature = "detection")]
+    pub skybox_creation_mode: SkyboxCreationMode,
 }
 
 impl Default for AtmosphereSettings {
@@ -24,6 +48,8 @@ impl Default for AtmosphereSettings {
             resolution: 512,
             #[cfg(feature = "dithering")]
             dithering: true,
+            #[cfg(feature = "detection")]
+            skybox_creation_mode: SkyboxCreationMode::default(),
         }
     }
 }


### PR DESCRIPTION
As per discussion in https://github.com/JonahPlusPlus/bevy_atmosphere/issues/75