### PR TITLE
Add feature gates to fix errors and warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,27 @@ jobs:
       - name: Rustdoc
         run: cargo rustdoc -- -D warnings
 
+  feature-combinations:
+    name: Feature combinations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+
+      - name: Instal stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache crates
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Cargo Hack
+        run: cargo install cargo-hack
+
+      - name: Check feature combinations
+        run: cargo hack check --feature-powerset
+        env:
+          RUSTFLAGS: -Aunused -Dwarnings
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -180,6 +180,7 @@ fn atmosphere_settings_changed(
                     depth_or_array_layers: 6,
                 };
                 image.resize(size);
+                #[cfg(feature = "dithering")]
                 if let Some(skybox_material) = material_assets.get_mut(&material.0) {
                     // `get_mut` tells the material to update, so it's needed anyways
                     skybox_material.dithering = settings.dithering;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,24 +2,25 @@
 
 use bevy::{
     asset::load_internal_asset,
-    pbr::{NotShadowCaster, NotShadowReceiver},
     prelude::*,
-    render::{
-        camera::{CameraProjection, Projection},
-        view::RenderLayers,
-        RenderApp,
-    },
+    render::{view::RenderLayers, RenderApp},
 };
 
 use crate::{
-    model::AddAtmosphereModel,
     pipeline::*,
-    settings::AtmosphereSettings,
     skybox::{AtmosphereSkyBoxMaterial, SkyBoxMaterial, ATMOSPHERE_SKYBOX_SHADER_HANDLE},
 };
 
 #[cfg(feature = "detection")]
-use crate::settings::SkyboxCreationMode;
+use crate::settings::{AtmosphereSettings, SkyboxCreationMode};
+#[cfg(feature = "detection")]
+use bevy::{
+    pbr::{NotShadowCaster, NotShadowReceiver},
+    render::camera::CameraProjection as _,
+};
+
+#[cfg(any(feature = "gradient", feature = "nishita"))]
+use crate::model::AddAtmosphereModel as _;
 
 /// A `Plugin` that adds the prerequisites for a procedural sky.
 #[derive(Debug, Clone, Copy)]
@@ -45,6 +46,7 @@ impl Plugin for AtmospherePlugin {
                 image.handle.clone()
             };
 
+            #[cfg(feature = "dithering")]
             let settings = {
                 let settings = app
                     .world()

--- a/src/skybox.rs
+++ b/src/skybox.rs
@@ -6,9 +6,12 @@ use bevy::{
     reflect::TypePath,
     render::{
         mesh::{Indices, Mesh, MeshVertexBufferLayoutRef, PrimitiveTopology},
-        render_resource::{AsBindGroup, RenderPipelineDescriptor, ShaderDefVal, ShaderRef},
+        render_resource::{AsBindGroup, RenderPipelineDescriptor, ShaderRef},
     },
 };
+
+#[cfg(feature = "dithering")]
+use bevy::render::render_resource::ShaderDefVal;
 
 /// The `Handle` for the created [`SkyBoxMaterial`].
 #[derive(Resource)]
@@ -44,9 +47,12 @@ impl Material for SkyBoxMaterial {
 
     fn specialize(
         _pipeline: &MaterialPipeline<Self>,
+        #[cfg_attr(not(feature = "dithering"), allow(unused_variables))]
         descriptor: &mut RenderPipelineDescriptor,
         _layout: &MeshVertexBufferLayoutRef,
-        key: MaterialPipelineKey<Self>,
+        #[cfg_attr(not(feature = "dithering"), allow(unused_variables))] key: MaterialPipelineKey<
+            Self,
+        >,
     ) -> Result<(), bevy::render::render_resource::SpecializedMeshPipelineError> {
         #[cfg(feature = "dithering")]
         if key.bind_group_data.dithering {
@@ -62,7 +68,9 @@ impl Material for SkyBoxMaterial {
 }
 
 impl From<&SkyBoxMaterial> for SkyBoxMaterialKey {
-    fn from(material: &SkyBoxMaterial) -> SkyBoxMaterialKey {
+    fn from(
+        #[cfg_attr(not(feature = "dithering"), allow(unused_variables))] material: &SkyBoxMaterial,
+    ) -> SkyBoxMaterialKey {
         SkyBoxMaterialKey {
             #[cfg(feature = "dithering")]
             dithering: material.dithering,


### PR DESCRIPTION
Fixes #78 

I didn't test every possible feature permutation, but I did test each feature individually and with all/default enabled. No more build errors/warnings!