### PR TITLE
Clear update events in `RenderSet::Cleanup`

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -138,7 +138,7 @@ impl Plugin for AtmospherePipelinePlugin {
             .insert_resource(settings)
             .insert_resource(AtmosphereTypeRegistry(type_registry))
             .init_resource::<CachedAtmosphereModelMetadata>()
-            .add_event::<AtmosphereUpdateEvent>()
+            .init_resource::<Events<AtmosphereUpdateEvent>>()
             .add_systems(ExtractSchedule, extract_atmosphere_resources)
             .add_systems(
                 Render,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -145,6 +145,7 @@ impl Plugin for AtmospherePipelinePlugin {
                 (
                     prepare_atmosphere_resources.in_set(RenderSet::PrepareResources),
                     prepare_atmosphere_bind_group.in_set(RenderSet::PrepareBindGroups),
+                    clear_update_events.in_set(RenderSet::Cleanup),
                 ),
             );
 
@@ -521,4 +522,8 @@ impl render_graph::Node for AtmosphereNode {
 
         Ok(())
     }
+}
+
+fn clear_update_events(mut update_events: ResMut<Events<AtmosphereUpdateEvent>>) {
+    update_events.clear();
 }


### PR DESCRIPTION
While digging around, I noticed something suspicious: `AtmosphereUpdateEvent`s weren't getting read via the normal `EventReader`, and I couldn't see where they were being cleared. So I put a `println` right before the call to `dispatch` the compute shader, and sure enough, it was getting run *every frame*! Honestly impressive that it was still running at such great framerates before the fix. My solution is to just clear all `AtmosphereUpdateEvent`s in `RenderSet::Cleanup`.