### PR TITLE
Derive Default for AtmospherePlugin

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -23,7 +23,7 @@ use bevy::{
 use crate::model::AddAtmosphereModel as _;
 
 /// A `Plugin` that adds the prerequisites for a procedural sky.
-#[derive(Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct AtmospherePlugin;
 
 impl Plugin for AtmospherePlugin {


### PR DESCRIPTION
The [plugin_group! macro](https://docs.rs/bevy/0.16.1/bevy/app/macro.plugin_group.html) allows easy creation for [PluginGroup](https://docs.rs/bevy/0.16.1/bevy/prelude/trait.PluginGroup.html)s. A requirement for using this macro is that plugins need to derive the `Default` trait. As the `AtmospherePlugin` has no fields right now, it's a no-brainer to derive Default for the AtmospherePlugin.